### PR TITLE
Add accordion sections to How to Play modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -135,22 +135,32 @@
         <div class="modal" id="help-modal">
             <div class="modal-content">
                 <h2>How to Play</h2>
-                <p>Guess the answer to estimation questions in 6 or less tries.</p>
-                <p>After each guess, you'll see if your answer was too high or too low. An arrow pointing down means that the correct answer is below your guess.</p>
-                <p>The color of the arrows shows how close you are: orange indicates your guess is within ±50% of the answer, red means it is further away</p>
-                <p>You win if your guess is within ±20% of the correct answer.</p>
+                <div class="accordion" id="help-accordion">
+                    <div class="accordion-item" id="acc-strategy-item">
+                        <button class="accordion-header" id="acc-strategy-header" aria-expanded="false" aria-controls="acc-strategy-panel">
+                            <span>Strategy Tips</span>
+                            <span class="acc-arrow">></span>
+                        </button>
+                        <div class="accordion-panel" id="acc-strategy-panel">
+                            <p>Make a Fermi estimate: break the problem into simple factors, choose round numbers, then multiply.</p>
+                            <p>Example: How many pizzas are eaten in NYC per day?</p>
+                            <p>Population ≈ 8M. About half eat pizza weekly → 4M people. Typical serving ≈ 2 slices per person per week → 8M slices/week. Per day ≈ 8M/7 ≈ 1.1M slices/day. ≈ 8 slices/pizza → ~140k pizzas/day.</p>
+                        </div>
+                    </div>
+                    <div class="accordion-item open" id="acc-rules-item">
+                        <button class="accordion-header" id="acc-rules-header" aria-expanded="true" aria-controls="acc-rules-panel">
+                            <span>Rules</span>
+                            <span class="acc-arrow">></span>
+                        </button>
+                        <div class="accordion-panel" id="acc-rules-panel">
+                            <p>Guess the answer to estimation questions in 6 or less tries.</p>
+                            <p>After each guess, you'll see if your answer was too high or too low. An arrow pointing down means that the correct answer is below your guess.</p>
+                            <p>The color of the arrows shows how close you are: orange indicates your guess is within ±50% of the answer, red means it is further away</p>
+                            <p>You win if your guess is within ±20% of the correct answer.</p>
+                        </div>
+                    </div>
+                </div>
                 <button id="close-help-btn" class="close-btn">Close</button>
-            </div>
-        </div>
-
-        <!-- Strategy Tips Modal -->
-        <div class="modal" id="strategy-modal">
-            <div class="modal-content">
-                <h2>Strategy tips</h2>
-                <p>Make a Fermi estimate: break the problem into simple factors, choose round numbers, then multiply.</p>
-                <p>Example: How many pizzas are eaten in NYC per day?</p>
-                <p>Population ≈ 8M. About half eat pizza weekly → 4M people. Typical serving ≈ 2 slices per person per week → 8M slices/week. Per day ≈ 8M/7 ≈ 1.1M slices/day. ≈ 8 slices/pizza → ~140k pizzas/day.</p>
-                <button id="close-strategy-btn" class="close-btn">Close</button>
             </div>
         </div>
 

--- a/script.js
+++ b/script.js
@@ -711,9 +711,7 @@ const statsBtn = document.getElementById('stats-btn');
 const helpModal = document.getElementById('help-modal');
 const statsModal = document.getElementById('stats-modal');
 const questionsModal = document.getElementById('questions-modal');
-const strategyModal = document.getElementById('strategy-modal');
 const strategyTipsBtn = document.getElementById('strategy-tips-btn');
-const closeStrategyBtn = document.getElementById('close-strategy-btn');
 // Hint modal elements
 const hintModal = document.getElementById('hint-modal');
 const hintModalBtn = document.getElementById('hint-modal-btn');
@@ -1413,11 +1411,6 @@ function startNewGameFromModal() {
 // Show help modal
 function showHelp() {
     helpModal.style.display = 'block';
-}
-
-// Show strategy modal
-function showStrategy() {
-    if (strategyModal) strategyModal.style.display = 'block';
 }
 
 // Show stats modal
@@ -2425,14 +2418,31 @@ function setupEventListeners() {
             });
         }
     }
+
+    // Help modal accordion toggles
+    const accStrategyItem = document.getElementById('acc-strategy-item');
+    const accStrategyHeader = document.getElementById('acc-strategy-header');
+    const accRulesItem = document.getElementById('acc-rules-item');
+    const accRulesHeader = document.getElementById('acc-rules-header');
+    if (accStrategyHeader && accStrategyItem) {
+        accStrategyHeader.addEventListener('click', () => {
+            const isOpen = accStrategyItem.classList.contains('open');
+            if (isOpen) accStrategyItem.classList.remove('open');
+            else accStrategyItem.classList.add('open');
+        });
+    }
+    if (accRulesHeader && accRulesItem) {
+        accRulesHeader.addEventListener('click', () => {
+            const isOpen = accRulesItem.classList.contains('open');
+            if (isOpen) accRulesItem.classList.remove('open');
+            else accRulesItem.classList.add('open');
+        });
+    }
     
     // Close buttons
     closeHelpBtn.addEventListener('click', () => closeModal(helpModal));
     closeStatsBtn.addEventListener('click', () => closeModal(statsModal));
     closeQuestionsBtn.addEventListener('click', () => closeModal(questionsModal));
-    if (closeStrategyBtn) {
-        closeStrategyBtn.addEventListener('click', () => closeModal(strategyModal));
-    }
     if (closeHintBtn) {
         closeHintBtn.addEventListener('click', () => closeModal(hintModal));
     }
@@ -2442,7 +2452,7 @@ function setupEventListeners() {
     shareStatsBtn.addEventListener('click', shareStats);
         
     // Close modals when clicking outside (desktop + mobile)
-    [helpModal, statsModal, questionsModal, strategyModal, hintModal, sourceModal].forEach(modal => {
+    [helpModal, statsModal, questionsModal, hintModal, sourceModal].forEach(modal => {
         ['click', 'touchend'].forEach(event => {
             modal.addEventListener(event, e => e.target === modal && closeModal(modal));
         });


### PR DESCRIPTION
## Summary
- Replace standalone strategy modal with accordion inside How to Play modal
- Add Strategy Tips and default-open Rules sections in help modal
- Wire up accordion toggles in JavaScript

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b6afd58ec08329a958ca33686e41d9