### PR TITLE
Add probability calibration option and chart

### DIFF
--- a/index.html
+++ b/index.html
@@ -103,13 +103,25 @@
         <div class="input-section" id="input-section">
             <div class="input-row">
                 <div class="input-container">
-                    <input 
-                        type="text" 
-                        id="guess-input" 
-                        placeholder="Enter a guess..." 
+                    <input
+                        type="text"
+                        id="guess-input"
+                        placeholder="Enter a guess..."
                         inputmode="numeric"
                         pattern="[0-9,]*"
                     >
+                    <select id="confidence-input">
+                        <option value="10">10%</option>
+                        <option value="20">20%</option>
+                        <option value="30">30%</option>
+                        <option value="40">40%</option>
+                        <option value="50" selected>50%</option>
+                        <option value="60">60%</option>
+                        <option value="70">70%</option>
+                        <option value="80">80%</option>
+                        <option value="90">90%</option>
+                        <option value="100">100%</option>
+                    </select>
                 </div>
                 <button id="submit-btn" class="submit-btn">Submit</button>
             </div>
@@ -139,6 +151,9 @@
                 <p>After each guess, you'll see if your answer was too high or too low. An arrow pointing down means that the correct answer is below your guess.</p>
                 <p>The color of the arrows shows how close you are: orange indicates your guess is within ±50% of the answer, red means it is further away</p>
                 <p>You win if your guess is within ±20% of the correct answer.</p>
+                <label class="calibration-toggle">
+                    <input type="checkbox" id="prob-calibration-checkbox"> Enable probability calibration
+                </label>
                 <button id="close-help-btn" class="close-btn">Close</button>
             </div>
         </div>
@@ -291,6 +306,17 @@
                                 <div class="dist-bar" id="dist-6" style="width: 0%"></div>
                             </div>
                             <span class="dist-count" id="count-6">0</span>
+                        </div>
+                    </div>
+                </div>
+                <div class="accordion" id="stats-accordion">
+                    <div class="accordion-item" id="acc-calibration-item">
+                        <button class="accordion-header" id="acc-calibration-header" aria-expanded="false" aria-controls="acc-calibration-panel">
+                            <span>Probability Calibration</span>
+                            <span class="acc-arrow">></span>
+                        </button>
+                        <div class="accordion-panel" id="acc-calibration-panel">
+                            <svg id="calibration-chart" width="300" height="200"></svg>
                         </div>
                     </div>
                 </div>

--- a/index.html
+++ b/index.html
@@ -270,8 +270,8 @@
                             </div>
                         </div>
                     </div>
-                    <div class="accordion-item open" id="acc-distribution-item">
-                        <button class="accordion-header" id="acc-distribution-header" aria-expanded="true" aria-controls="acc-distribution-panel">
+                    <div class="accordion-item" id="acc-distribution-item">
+                        <button class="accordion-header" id="acc-distribution-header" aria-expanded="false" aria-controls="acc-distribution-panel">
                             <span>Guess Distribution</span>
                             <span class="acc-arrow">></span>
                         </button>
@@ -324,8 +324,8 @@
                             </div>
                         </div>
                     </div>
-                    <div class="accordion-item" id="acc-calibration-item">
-                        <button class="accordion-header" id="acc-calibration-header" aria-expanded="false" aria-controls="acc-calibration-panel">
+                    <div class="accordion-item open" id="acc-calibration-item">
+                        <button class="accordion-header" id="acc-calibration-header" aria-expanded="true" aria-controls="acc-calibration-panel">
                             <span>Probability Calibration</span>
                             <span class="acc-arrow">></span>
                         </button>
@@ -338,7 +338,9 @@
                                     <input type="checkbox" id="first-guess-checkbox"> Only count first guesses
                                 </label>
                             </div>
-                            <svg id="calibration-chart" width="300" height="200"></svg>
+                            <div class="calibration-chart-wrapper">
+                                <svg id="calibration-chart" width="300" height="200"></svg>
+                            </div>
                             <div id="calibration-tooltip" class="chart-tooltip"></div>
                         </div>
                     </div>

--- a/index.html
+++ b/index.html
@@ -120,6 +120,7 @@
                         <option value="70">70%</option>
                         <option value="80">80%</option>
                         <option value="90">90%</option>
+                        <option value="100">100%</option>
                     </select>
                 </div>
                 <button id="submit-btn" class="submit-btn">Submit</button>
@@ -337,7 +338,7 @@
                                     <input type="checkbox" id="first-guess-checkbox"> Only count first guesses
                                 </label>
                             </div>
-                            <p class="calibration-note">Enable probability calibration and make a guess to see data.</p>
+                            <p class="calibration-note">No data yet</p>
                             <div class="calibration-chart-wrapper">
                                 <svg id="calibration-chart" width="300" height="200"></svg>
                             </div>

--- a/index.html
+++ b/index.html
@@ -152,7 +152,7 @@
                 <p>The color of the arrows shows how close you are: orange indicates your guess is within ±50% of the answer, red means it is further away</p>
                 <p>You win if your guess is within ±20% of the correct answer.</p>
                 <label class="calibration-toggle">
-                    <input type="checkbox" id="prob-calibration-checkbox"> Enable probability calibration
+                    <input type="checkbox" id="prob-calibration-checkbox" class="prob-calibration-checkbox"> Enable probability calibration
                 </label>
                 <button id="close-help-btn" class="close-btn">Close</button>
             </div>
@@ -235,81 +235,95 @@
         <div class="modal" id="stats-modal">
             <div class="modal-content">
                 <h2>Statistics</h2>
-                <div class="stats-grid">
-                    <div class="stat-item">
-                        <span class="stat-number" id="games-played">0</span>
-                        <span class="stat-label">Games Played</span>
-                    </div>
-                    <div class="stat-item">
-                        <span class="stat-number" id="games-won">0</span>
-                        <span class="stat-label">Games Won</span>
-                    </div>
-                    <div class="stat-item">
-                        <span class="stat-number" id="win-rate">0%</span>
-                        <span class="stat-label">Win Rate</span>
-                    </div>
-                    <div class="stat-item">
-                        <span class="stat-number" id="current-streak">0</span>
-                        <span class="stat-label">Current Streak</span>
-                    </div>
-                    <div class="stat-item">
-                        <span class="stat-number" id="max-streak">0</span>
-                        <span class="stat-label">Max Streak</span>
-                    </div>
-                    <div class="stat-item">
-                        <span class="stat-number" id="guess-average">0</span>
-                        <span class="stat-label">Guess Average</span>
-                    </div>
-                </div>
-                
-                <div class="guess-distribution">
-                    <h3>Guess Distribution</h3>
-                    <div class="distribution-bars">
-                        <div class="dist-row">
-                            <span class="dist-label">1</span>
-                            <div class="dist-bar-container">
-                                <div class="dist-bar" id="dist-1" style="width: 0%"></div>
-                            </div>
-                            <span class="dist-count" id="count-1">0</span>
-                        </div>
-                        <div class="dist-row">
-                            <span class="dist-label">2</span>
-                            <div class="dist-bar-container">
-                                <div class="dist-bar" id="dist-2" style="width: 0%"></div>
-                            </div>
-                            <span class="dist-count" id="count-2">0</span>
-                        </div>
-                        <div class="dist-row">
-                            <span class="dist-label">3</span>
-                            <div class="dist-bar-container">
-                                <div class="dist-bar" id="dist-3" style="width: 0%"></div>
-                            </div>
-                            <span class="dist-count" id="count-3">0</span>
-                        </div>
-                        <div class="dist-row">
-                            <span class="dist-label">4</span>
-                            <div class="dist-bar-container">
-                                <div class="dist-bar" id="dist-4" style="width: 0%"></div>
-                            </div>
-                            <span class="dist-count" id="count-4">0</span>
-                        </div>
-                        <div class="dist-row">
-                            <span class="dist-label">5</span>
-                            <div class="dist-bar-container">
-                                <div class="dist-bar" id="dist-5" style="width: 0%"></div>
-                            </div>
-                            <span class="dist-count" id="count-5">0</span>
-                        </div>
-                        <div class="dist-row">
-                            <span class="dist-label">6</span>
-                            <div class="dist-bar-container">
-                                <div class="dist-bar" id="dist-6" style="width: 0%"></div>
-                            </div>
-                            <span class="dist-count" id="count-6">0</span>
-                        </div>
-                    </div>
-                </div>
                 <div class="accordion" id="stats-accordion">
+                    <div class="accordion-item open" id="acc-statsgrid-item">
+                        <button class="accordion-header" id="acc-statsgrid-header" aria-expanded="true" aria-controls="acc-statsgrid-panel">
+                            <span>Stats</span>
+                            <span class="acc-arrow">></span>
+                        </button>
+                        <div class="accordion-panel" id="acc-statsgrid-panel">
+                            <div class="stats-grid">
+                                <div class="stat-item">
+                                    <span class="stat-number" id="games-played">0</span>
+                                    <span class="stat-label">Games Played</span>
+                                </div>
+                                <div class="stat-item">
+                                    <span class="stat-number" id="games-won">0</span>
+                                    <span class="stat-label">Games Won</span>
+                                </div>
+                                <div class="stat-item">
+                                    <span class="stat-number" id="win-rate">0%</span>
+                                    <span class="stat-label">Win Rate</span>
+                                </div>
+                                <div class="stat-item">
+                                    <span class="stat-number" id="current-streak">0</span>
+                                    <span class="stat-label">Current Streak</span>
+                                </div>
+                                <div class="stat-item">
+                                    <span class="stat-number" id="max-streak">0</span>
+                                    <span class="stat-label">Max Streak</span>
+                                </div>
+                                <div class="stat-item">
+                                    <span class="stat-number" id="guess-average">0</span>
+                                    <span class="stat-label">Guess Average</span>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="accordion-item open" id="acc-distribution-item">
+                        <button class="accordion-header" id="acc-distribution-header" aria-expanded="true" aria-controls="acc-distribution-panel">
+                            <span>Guess Distribution</span>
+                            <span class="acc-arrow">></span>
+                        </button>
+                        <div class="accordion-panel" id="acc-distribution-panel">
+                            <div class="guess-distribution">
+                                <div class="distribution-bars">
+                                    <div class="dist-row">
+                                        <span class="dist-label">1</span>
+                                        <div class="dist-bar-container">
+                                            <div class="dist-bar" id="dist-1" style="width: 0%"></div>
+                                        </div>
+                                        <span class="dist-count" id="count-1">0</span>
+                                    </div>
+                                    <div class="dist-row">
+                                        <span class="dist-label">2</span>
+                                        <div class="dist-bar-container">
+                                            <div class="dist-bar" id="dist-2" style="width: 0%"></div>
+                                        </div>
+                                        <span class="dist-count" id="count-2">0</span>
+                                    </div>
+                                    <div class="dist-row">
+                                        <span class="dist-label">3</span>
+                                        <div class="dist-bar-container">
+                                            <div class="dist-bar" id="dist-3" style="width: 0%"></div>
+                                        </div>
+                                        <span class="dist-count" id="count-3">0</span>
+                                    </div>
+                                    <div class="dist-row">
+                                        <span class="dist-label">4</span>
+                                        <div class="dist-bar-container">
+                                            <div class="dist-bar" id="dist-4" style="width: 0%"></div>
+                                        </div>
+                                        <span class="dist-count" id="count-4">0</span>
+                                    </div>
+                                    <div class="dist-row">
+                                        <span class="dist-label">5</span>
+                                        <div class="dist-bar-container">
+                                            <div class="dist-bar" id="dist-5" style="width: 0%"></div>
+                                        </div>
+                                        <span class="dist-count" id="count-5">0</span>
+                                    </div>
+                                    <div class="dist-row">
+                                        <span class="dist-label">6</span>
+                                        <div class="dist-bar-container">
+                                            <div class="dist-bar" id="dist-6" style="width: 0%"></div>
+                                        </div>
+                                        <span class="dist-count" id="count-6">0</span>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
                     <div class="accordion-item" id="acc-calibration-item">
                         <button class="accordion-header" id="acc-calibration-header" aria-expanded="false" aria-controls="acc-calibration-panel">
                             <span>Probability Calibration</span>
@@ -317,6 +331,9 @@
                         </button>
                         <div class="accordion-panel" id="acc-calibration-panel">
                             <div class="calibration-options">
+                                <label>
+                                    <input type="checkbox" id="prob-calibration-checkbox-stats" class="prob-calibration-checkbox"> Enable probability calibration
+                                </label>
                                 <label>
                                     <input type="checkbox" id="first-guess-checkbox"> Only count first guesses
                                 </label>

--- a/index.html
+++ b/index.html
@@ -316,6 +316,11 @@
                             <span class="acc-arrow">></span>
                         </button>
                         <div class="accordion-panel" id="acc-calibration-panel">
+                            <div class="calibration-options">
+                                <label>
+                                    <input type="checkbox" id="first-guess-checkbox"> Only count first guesses
+                                </label>
+                            </div>
                             <svg id="calibration-chart" width="300" height="200"></svg>
                         </div>
                     </div>

--- a/index.html
+++ b/index.html
@@ -322,6 +322,7 @@
                                 </label>
                             </div>
                             <svg id="calibration-chart" width="300" height="200"></svg>
+                            <div id="calibration-tooltip" class="chart-tooltip"></div>
                         </div>
                     </div>
                 </div>

--- a/index.html
+++ b/index.html
@@ -120,7 +120,6 @@
                         <option value="70">70%</option>
                         <option value="80">80%</option>
                         <option value="90">90%</option>
-                        <option value="100">100%</option>
                     </select>
                 </div>
                 <button id="submit-btn" class="submit-btn">Submit</button>
@@ -338,9 +337,11 @@
                                     <input type="checkbox" id="first-guess-checkbox"> Only count first guesses
                                 </label>
                             </div>
+                            <p class="calibration-note">Enable probability calibration and make a guess to see data.</p>
                             <div class="calibration-chart-wrapper">
                                 <svg id="calibration-chart" width="300" height="200"></svg>
                             </div>
+                            <p class="calibration-description">The x-axis shows your declared confidence, and the y-axis shows the actual accuracy. You are perfectly calibrated if you are on the diagonal line.</p>
                             <div id="calibration-tooltip" class="chart-tooltip"></div>
                         </div>
                     </div>

--- a/script.js
+++ b/script.js
@@ -300,8 +300,11 @@ let stats = {
         4: 0,
         5: 0,
         6: 0
-    }
+    },
+    calibrationData: []
 };
+
+let calibrationEnabled = false;
 
 // Database of Fermi questions with dates
 const fermiQuestions = [
@@ -706,6 +709,7 @@ const resultEmoji = document.getElementById('result-emoji');
 const correctAnswer = document.getElementById('correct-answer');
 const guessesContainer = document.getElementById('guesses-container');
 const guessInput = document.getElementById('guess-input');
+const confidenceInput = document.getElementById('confidence-input');
 const submitBtn = document.getElementById('submit-btn');
 const inputSection = document.getElementById('input-section');
 const newGameSection = document.getElementById('new-game-section');
@@ -736,14 +740,16 @@ const shareBtn = document.getElementById('share-btn');
 const shareStatsBtn = document.getElementById('share-stats-btn');
 const medianFirstGuessText = document.getElementById('median-first-guess-text');
 const firstGuessPercentileText = document.getElementById('first-guess-percentile-text');
+const calibrationCheckbox = document.getElementById('prob-calibration-checkbox');
 
 // Initialize game
 function initGame() {
     // Initialize Supabase first
     initSupabase();
-    
+
     loadStats();
     loadCompletedQuestions();
+    loadCalibrationSetting();
 
     // If URL has a specific question date, navigate to it first
     let navigatedFromURL = false;
@@ -956,14 +962,15 @@ function getGuessText(guessNumber) {
 // Submit a guess
 function submitGuess() {
     const guessValue = parseInt(guessInput.value.replace(/[^\d]/g, ''));
-    
+    const confidenceValue = confidenceInput ? parseInt(confidenceInput.value) : null;
+
     if (isNaN(guessValue) || guessValue < 0) {
         alert('Please enter a valid positive number!');
         return;
     }
-    
+
     currentGuess++;
-    
+
     // Add guess to display
     addGuessToDisplay(guessValue);
     
@@ -1024,6 +1031,15 @@ function submitGuess() {
     
     // Clear input
     guessInput.value = '';
+
+    if (calibrationEnabled && confidenceInput) {
+        const confPercent = isNaN(confidenceValue) ? null : Math.max(0, Math.min(100, confidenceValue));
+        if (confPercent !== null) {
+            stats.calibrationData.push({ confidence: confPercent / 100, correct: isCorrect });
+            saveStats();
+        }
+        confidenceInput.value = '50';
+    }
     
     // Save current game state after each guess
     saveCurrentGameState();
@@ -1482,6 +1498,160 @@ function updateStatsDisplay() {
             barElement.style.width = `${percentage}%`;
         }
     }
+
+    updateCalibrationChart();
+}
+
+function updateCalibrationChart() {
+    const svg = document.getElementById('calibration-chart');
+    if (!svg) return;
+
+    while (svg.firstChild) svg.removeChild(svg.firstChild);
+
+    const width = svg.viewBox.baseVal?.width || svg.width.baseVal.value || 300;
+    const height = svg.viewBox.baseVal?.height || svg.height.baseVal.value || 200;
+
+    const data = stats.calibrationData || [];
+    if (data.length === 0) {
+        const text = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+        text.setAttribute('x', 10);
+        text.setAttribute('y', 20);
+        text.setAttribute('fill', '#666');
+        text.setAttribute('font-size', '12');
+        text.textContent = 'No data';
+        svg.appendChild(text);
+        return;
+    }
+
+    const bins = Array.from({ length: 10 }, () => ({ total: 0, correct: 0 }));
+    data.forEach(d => {
+        let conf = typeof d.confidence === 'number' ? d.confidence : parseFloat(d.confidence);
+        if (isNaN(conf)) return;
+        conf = Math.max(0, Math.min(1, conf));
+        const idx = Math.min(9, Math.round(conf * 10) - 1);
+        if (idx >= 0) {
+            bins[idx].total++;
+            if (d.correct) bins[idx].correct++;
+        }
+    });
+
+    const paddingLeft = 30,
+        paddingBottom = 30,
+        paddingTop = 20,
+        paddingRight = 20;
+    const plotWidth = width - paddingLeft - paddingRight;
+    const plotHeight = height - paddingTop - paddingBottom;
+
+    const ns = 'http://www.w3.org/2000/svg';
+
+    // Axes
+    const xAxis = document.createElementNS(ns, 'line');
+    xAxis.setAttribute('x1', paddingLeft);
+    xAxis.setAttribute('y1', height - paddingBottom);
+    xAxis.setAttribute('x2', width - paddingRight);
+    xAxis.setAttribute('y2', height - paddingBottom);
+    xAxis.setAttribute('stroke', '#ccc');
+    svg.appendChild(xAxis);
+
+    const yAxis = document.createElementNS(ns, 'line');
+    yAxis.setAttribute('x1', paddingLeft);
+    yAxis.setAttribute('y1', height - paddingBottom);
+    yAxis.setAttribute('x2', paddingLeft);
+    yAxis.setAttribute('y2', paddingTop);
+    yAxis.setAttribute('stroke', '#ccc');
+    svg.appendChild(yAxis);
+
+    // Diagonal line
+    const diag = document.createElementNS(ns, 'line');
+    diag.setAttribute('x1', paddingLeft);
+    diag.setAttribute('y1', height - paddingBottom);
+    diag.setAttribute('x2', width - paddingRight);
+    diag.setAttribute('y2', paddingTop);
+    diag.setAttribute('stroke', '#eee');
+    svg.appendChild(diag);
+
+    // Ticks and labels
+    for (let i = 10; i <= 100; i += 10) {
+        const x = paddingLeft + (i / 100) * plotWidth;
+        const y = height - paddingBottom - (i / 100) * plotHeight;
+
+        const xTick = document.createElementNS(ns, 'line');
+        xTick.setAttribute('x1', x);
+        xTick.setAttribute('y1', height - paddingBottom);
+        xTick.setAttribute('x2', x);
+        xTick.setAttribute('y2', height - paddingBottom + 5);
+        xTick.setAttribute('stroke', '#ccc');
+        svg.appendChild(xTick);
+
+        const xLabel = document.createElementNS(ns, 'text');
+        xLabel.setAttribute('x', x);
+        xLabel.setAttribute('y', height - paddingBottom + 15);
+        xLabel.setAttribute('text-anchor', 'middle');
+        xLabel.setAttribute('font-size', '10');
+        xLabel.textContent = `${i}%`;
+        svg.appendChild(xLabel);
+
+        const yTick = document.createElementNS(ns, 'line');
+        yTick.setAttribute('x1', paddingLeft - 5);
+        yTick.setAttribute('y1', y);
+        yTick.setAttribute('x2', paddingLeft);
+        yTick.setAttribute('y2', y);
+        yTick.setAttribute('stroke', '#ccc');
+        svg.appendChild(yTick);
+
+        const yLabel = document.createElementNS(ns, 'text');
+        yLabel.setAttribute('x', paddingLeft - 8);
+        yLabel.setAttribute('y', y + 3);
+        yLabel.setAttribute('text-anchor', 'end');
+        yLabel.setAttribute('font-size', '10');
+        yLabel.textContent = `${i}%`;
+        svg.appendChild(yLabel);
+    }
+
+    // Calibration curve
+    const points = [];
+    bins.forEach((bin, i) => {
+        const x = paddingLeft + ((i + 1) / 10) * plotWidth;
+        const ratio = bin.total ? (bin.correct / bin.total) : 0;
+        const y = height - paddingBottom - ratio * plotHeight;
+        points.push(`${x},${y}`);
+    });
+
+    const polyline = document.createElementNS(ns, 'polyline');
+    polyline.setAttribute('points', points.join(' '));
+    polyline.setAttribute('fill', 'none');
+    polyline.setAttribute('stroke', '#3498db');
+    svg.appendChild(polyline);
+
+    bins.forEach((bin, i) => {
+        const x = paddingLeft + ((i + 1) / 10) * plotWidth;
+        const ratio = bin.total ? (bin.correct / bin.total) : 0;
+        const y = height - paddingBottom - ratio * plotHeight;
+        const circle = document.createElementNS(ns, 'circle');
+        circle.setAttribute('cx', x);
+        circle.setAttribute('cy', y);
+        circle.setAttribute('r', 3);
+        circle.setAttribute('fill', '#3498db');
+        svg.appendChild(circle);
+    });
+
+    // Axis labels
+    const xAxisLabel = document.createElementNS(ns, 'text');
+    xAxisLabel.setAttribute('x', paddingLeft + plotWidth / 2);
+    xAxisLabel.setAttribute('y', height - 5);
+    xAxisLabel.setAttribute('text-anchor', 'middle');
+    xAxisLabel.setAttribute('font-size', '10');
+    xAxisLabel.textContent = 'Declared confidence (%)';
+    svg.appendChild(xAxisLabel);
+
+    const yAxisLabel = document.createElementNS(ns, 'text');
+    yAxisLabel.setAttribute('x', 15);
+    yAxisLabel.setAttribute('y', paddingTop + plotHeight / 2);
+    yAxisLabel.setAttribute('text-anchor', 'middle');
+    yAxisLabel.setAttribute('font-size', '10');
+    yAxisLabel.setAttribute('transform', `rotate(-90 15 ${paddingTop + plotHeight / 2})`);
+    yAxisLabel.textContent = 'Actual accuracy (%)';
+    svg.appendChild(yAxisLabel);
 }
 
 // Close modals
@@ -1516,7 +1686,8 @@ function loadStats() {
                     4: 0,
                     5: 0,
                     6: 0
-                }
+                },
+                calibrationData: loadedStats.calibrationData || []
             };
         } catch (error) {
             console.error('Error loading stats:', error);
@@ -1534,7 +1705,8 @@ function loadStats() {
                     4: 0,
                     5: 0,
                     6: 0
-                }
+                },
+                calibrationData: []
             };
         }
     }
@@ -1554,6 +1726,31 @@ function loadCompletedQuestions() {
         } catch (error) {
             console.error('Error loading completed questions:', error);
             completedQuestions = {}; // Reset to default on error
+        }
+    }
+}
+
+function loadCalibrationSetting() {
+    calibrationEnabled = localStorage.getItem('fermiCalibrationEnabled') === 'true';
+    if (calibrationCheckbox) {
+        calibrationCheckbox.checked = calibrationEnabled;
+    }
+    updateConfidenceInputVisibility();
+}
+
+function setCalibrationEnabled(enabled) {
+    calibrationEnabled = enabled;
+    localStorage.setItem('fermiCalibrationEnabled', enabled ? 'true' : 'false');
+    updateConfidenceInputVisibility();
+}
+
+function updateConfidenceInputVisibility() {
+    if (confidenceInput) {
+        confidenceInput.style.display = calibrationEnabled ? 'block' : 'none';
+        if (calibrationEnabled) {
+            confidenceInput.value = '50';
+        } else {
+            confidenceInput.value = '';
         }
     }
 }
@@ -2344,6 +2541,12 @@ function setupEventListeners() {
     
     // Questions history button (question category)
     questionCategory.addEventListener('click', showQuestionsHistory);
+
+    if (calibrationCheckbox) {
+        calibrationCheckbox.addEventListener('change', (e) => {
+            setCalibrationEnabled(e.target.checked);
+        });
+    }
     
     // Source button opens explanation modal
     if (sourceBtn && sourceModal) {
@@ -2433,6 +2636,16 @@ function setupEventListeners() {
                 else accInitialItem.classList.add('open');
             });
         }
+    }
+
+    const accCalibrationItem = document.getElementById('acc-calibration-item');
+    const accCalibrationHeader = document.getElementById('acc-calibration-header');
+    if (accCalibrationHeader && accCalibrationItem) {
+        accCalibrationHeader.addEventListener('click', () => {
+            const isOpen = accCalibrationItem.classList.contains('open');
+            if (isOpen) accCalibrationItem.classList.remove('open');
+            else accCalibrationItem.classList.add('open');
+        });
     }
     
     // Close buttons

--- a/script.js
+++ b/script.js
@@ -744,6 +744,7 @@ const calibrationCheckboxes = document.querySelectorAll('.prob-calibration-check
 const firstGuessCheckbox = document.getElementById('first-guess-checkbox');
 const calibrationChart = document.getElementById('calibration-chart');
 const calibrationTooltip = document.getElementById('calibration-tooltip');
+const calibrationNote = document.querySelector('.calibration-note');
 
 // Initialize game
 function initGame() {
@@ -1557,6 +1558,11 @@ function updateCalibrationChart() {
 
     const ns = 'http://www.w3.org/2000/svg';
 
+    const hasData = bins.some(bin => bin.total > 0);
+    if (calibrationNote) {
+        calibrationNote.style.display = hasData ? 'none' : 'block';
+    }
+
     // Axes
     const xAxis = document.createElementNS(ns, 'line');
     xAxis.setAttribute('x1', paddingLeft);
@@ -1744,6 +1750,15 @@ function updateConfidenceInputVisibility() {
             confidenceInput.value = '50';
         } else {
             confidenceInput.value = '';
+        }
+    }
+    if (submitBtn) {
+        if (calibrationEnabled && isSmallDevice()) {
+            submitBtn.style.width = '54px';
+            submitBtn.textContent = '>';
+        } else {
+            submitBtn.style.width = '';
+            submitBtn.textContent = 'Submit';
         }
     }
 }
@@ -2713,4 +2728,5 @@ document.addEventListener('click', (e) => {
 });
 
 // Initialize the game when the page loads
+window.addEventListener('resize', updateConfidenceInputVisibility);
 document.addEventListener('DOMContentLoaded', initGame);

--- a/script.js
+++ b/script.js
@@ -740,7 +740,7 @@ const shareBtn = document.getElementById('share-btn');
 const shareStatsBtn = document.getElementById('share-stats-btn');
 const medianFirstGuessText = document.getElementById('median-first-guess-text');
 const firstGuessPercentileText = document.getElementById('first-guess-percentile-text');
-const calibrationCheckbox = document.getElementById('prob-calibration-checkbox');
+const calibrationCheckboxes = document.querySelectorAll('.prob-calibration-checkbox');
 const firstGuessCheckbox = document.getElementById('first-guess-checkbox');
 const calibrationChart = document.getElementById('calibration-chart');
 const calibrationTooltip = document.getElementById('calibration-tooltip');
@@ -1557,8 +1557,8 @@ function updateCalibrationChart() {
         }
     });
 
-    const paddingLeft = 30,
-        paddingBottom = 30,
+    const paddingLeft = 50,
+        paddingBottom = 60,
         paddingTop = 20,
         paddingRight = 20;
     const plotWidth = width - paddingLeft - paddingRight;
@@ -1655,18 +1655,18 @@ function updateCalibrationChart() {
     // Axis labels
     const xAxisLabel = document.createElementNS(ns, 'text');
     xAxisLabel.setAttribute('x', paddingLeft + plotWidth / 2);
-    xAxisLabel.setAttribute('y', height - 5);
+    xAxisLabel.setAttribute('y', height - 10);
     xAxisLabel.setAttribute('text-anchor', 'middle');
     xAxisLabel.setAttribute('font-size', '10');
     xAxisLabel.textContent = 'Declared confidence (%)';
     svg.appendChild(xAxisLabel);
 
     const yAxisLabel = document.createElementNS(ns, 'text');
-    yAxisLabel.setAttribute('x', 15);
+    yAxisLabel.setAttribute('x', 20);
     yAxisLabel.setAttribute('y', paddingTop + plotHeight / 2);
     yAxisLabel.setAttribute('text-anchor', 'middle');
     yAxisLabel.setAttribute('font-size', '10');
-    yAxisLabel.setAttribute('transform', `rotate(-90 15 ${paddingTop + plotHeight / 2})`);
+    yAxisLabel.setAttribute('transform', `rotate(-90 20 ${paddingTop + plotHeight / 2})`);
     yAxisLabel.textContent = 'Actual accuracy (%)';
     svg.appendChild(yAxisLabel);
 }
@@ -1749,15 +1749,18 @@ function loadCompletedQuestions() {
 
 function loadCalibrationSetting() {
     calibrationEnabled = localStorage.getItem('fermiCalibrationEnabled') === 'true';
-    if (calibrationCheckbox) {
-        calibrationCheckbox.checked = calibrationEnabled;
-    }
+    calibrationCheckboxes.forEach(cb => {
+        cb.checked = calibrationEnabled;
+    });
     updateConfidenceInputVisibility();
 }
 
 function setCalibrationEnabled(enabled) {
     calibrationEnabled = enabled;
     localStorage.setItem('fermiCalibrationEnabled', enabled ? 'true' : 'false');
+    calibrationCheckboxes.forEach(cb => {
+        cb.checked = enabled;
+    });
     updateConfidenceInputVisibility();
 }
 
@@ -2559,9 +2562,11 @@ function setupEventListeners() {
     // Questions history button (question category)
     questionCategory.addEventListener('click', showQuestionsHistory);
 
-    if (calibrationCheckbox) {
-        calibrationCheckbox.addEventListener('change', (e) => {
-            setCalibrationEnabled(e.target.checked);
+    if (calibrationCheckboxes.length) {
+        calibrationCheckboxes.forEach(cb => {
+            cb.addEventListener('change', (e) => {
+                setCalibrationEnabled(e.target.checked);
+            });
         });
     }
 
@@ -2659,6 +2664,26 @@ function setupEventListeners() {
                 else accInitialItem.classList.add('open');
             });
         }
+    }
+
+    const accStatsGridItem = document.getElementById('acc-statsgrid-item');
+    const accStatsGridHeader = document.getElementById('acc-statsgrid-header');
+    if (accStatsGridHeader && accStatsGridItem) {
+        accStatsGridHeader.addEventListener('click', () => {
+            const isOpen = accStatsGridItem.classList.contains('open');
+            if (isOpen) accStatsGridItem.classList.remove('open');
+            else accStatsGridItem.classList.add('open');
+        });
+    }
+
+    const accDistributionItem = document.getElementById('acc-distribution-item');
+    const accDistributionHeader = document.getElementById('acc-distribution-header');
+    if (accDistributionHeader && accDistributionItem) {
+        accDistributionHeader.addEventListener('click', () => {
+            const isOpen = accDistributionItem.classList.contains('open');
+            if (isOpen) accDistributionItem.classList.remove('open');
+            else accDistributionItem.classList.add('open');
+        });
     }
 
     const accCalibrationItem = document.getElementById('acc-calibration-item');

--- a/script.js
+++ b/script.js
@@ -1528,6 +1528,7 @@ function updateCalibrationChart() {
 
     const width = svg.viewBox.baseVal?.width || svg.width.baseVal.value || 300;
     const height = svg.viewBox.baseVal?.height || svg.height.baseVal.value || 200;
+    svg.setAttribute('overflow', 'visible');
 
     const firstOnly = firstGuessCheckbox && firstGuessCheckbox.checked;
     let data = stats.calibrationData || [];
@@ -1608,9 +1609,9 @@ function updateCalibrationChart() {
         const xLabel = document.createElementNS(ns, 'text');
         xLabel.setAttribute('x', x);
         xLabel.setAttribute('y', height - paddingBottom + 15);
-        xLabel.setAttribute('text-anchor', 'start');
+        xLabel.setAttribute('text-anchor', 'end');
         xLabel.setAttribute('font-size', '10');
-        xLabel.setAttribute('transform', `rotate(45 ${x} ${height - paddingBottom + 15})`);
+        xLabel.setAttribute('transform', `rotate(-45 ${x} ${height - paddingBottom + 15})`);
         xLabel.textContent = `${i}%`;
         svg.appendChild(xLabel);
 
@@ -1662,11 +1663,13 @@ function updateCalibrationChart() {
     svg.appendChild(xAxisLabel);
 
     const yAxisLabel = document.createElementNS(ns, 'text');
-    yAxisLabel.setAttribute('x', 20);
-    yAxisLabel.setAttribute('y', paddingTop + plotHeight / 2);
+    const yLabelX = paddingLeft - 40;
+    const yLabelY = paddingTop + plotHeight / 2;
+    yAxisLabel.setAttribute('x', yLabelX);
+    yAxisLabel.setAttribute('y', yLabelY);
     yAxisLabel.setAttribute('text-anchor', 'middle');
     yAxisLabel.setAttribute('font-size', '10');
-    yAxisLabel.setAttribute('transform', `rotate(-90 20 ${paddingTop + plotHeight / 2})`);
+    yAxisLabel.setAttribute('transform', `rotate(-90 ${yLabelX} ${yLabelY})`);
     yAxisLabel.textContent = 'Actual accuracy (%)';
     svg.appendChild(yAxisLabel);
 }

--- a/script.js
+++ b/script.js
@@ -1535,16 +1535,6 @@ function updateCalibrationChart() {
     if (firstOnly) {
         data = data.filter(d => d.guessNumber === 1);
     }
-    if (data.length === 0) {
-        const text = document.createElementNS('http://www.w3.org/2000/svg', 'text');
-        text.setAttribute('x', 10);
-        text.setAttribute('y', 20);
-        text.setAttribute('fill', '#666');
-        text.setAttribute('font-size', '12');
-        text.textContent = 'No data';
-        svg.appendChild(text);
-        return;
-    }
 
     const bins = Array.from({ length: 10 }, () => ({ total: 0, correct: 0 }));
     data.forEach(d => {
@@ -1652,26 +1642,6 @@ function updateCalibrationChart() {
         }, { passive: true });
         svg.appendChild(circle);
     });
-
-    // Axis labels
-    const xAxisLabel = document.createElementNS(ns, 'text');
-    xAxisLabel.setAttribute('x', paddingLeft + plotWidth / 2);
-    xAxisLabel.setAttribute('y', height - 10);
-    xAxisLabel.setAttribute('text-anchor', 'middle');
-    xAxisLabel.setAttribute('font-size', '10');
-    xAxisLabel.textContent = 'Confidence';
-    svg.appendChild(xAxisLabel);
-
-    const yAxisLabel = document.createElementNS(ns, 'text');
-    const yLabelX = paddingLeft - 40;
-    const yLabelY = paddingTop + plotHeight / 2;
-    yAxisLabel.setAttribute('x', yLabelX);
-    yAxisLabel.setAttribute('y', yLabelY);
-    yAxisLabel.setAttribute('text-anchor', 'middle');
-    yAxisLabel.setAttribute('font-size', '10');
-    yAxisLabel.setAttribute('transform', `rotate(-90 ${yLabelX} ${yLabelY})`);
-    yAxisLabel.textContent = 'Accuracy';
-    svg.appendChild(yAxisLabel);
 }
 
 // Close modals

--- a/script.js
+++ b/script.js
@@ -1607,11 +1607,11 @@ function updateCalibrationChart() {
         svg.appendChild(xTick);
 
         const xLabel = document.createElementNS(ns, 'text');
-        xLabel.setAttribute('x', x);
-        xLabel.setAttribute('y', height - paddingBottom + 15);
+        xLabel.setAttribute('x', x + 2);
+        xLabel.setAttribute('y', height - paddingBottom + 20);
         xLabel.setAttribute('text-anchor', 'end');
         xLabel.setAttribute('font-size', '10');
-        xLabel.setAttribute('transform', `rotate(-45 ${x + 2} ${height - paddingBottom + 20})`);
+        xLabel.setAttribute('transform', `rotate(-45 ${x} ${height - paddingBottom + 15})`);
         xLabel.textContent = `${i}%`;
         svg.appendChild(xLabel);
 
@@ -1659,7 +1659,7 @@ function updateCalibrationChart() {
     xAxisLabel.setAttribute('y', height - 10);
     xAxisLabel.setAttribute('text-anchor', 'middle');
     xAxisLabel.setAttribute('font-size', '10');
-    xAxisLabel.textContent = 'Declared confidence (%)';
+    xAxisLabel.textContent = 'Confidence';
     svg.appendChild(xAxisLabel);
 
     const yAxisLabel = document.createElementNS(ns, 'text');
@@ -1670,7 +1670,7 @@ function updateCalibrationChart() {
     yAxisLabel.setAttribute('text-anchor', 'middle');
     yAxisLabel.setAttribute('font-size', '10');
     yAxisLabel.setAttribute('transform', `rotate(-90 ${yLabelX} ${yLabelY})`);
-    yAxisLabel.textContent = 'Actual accuracy (%)';
+    yAxisLabel.textContent = 'Accuracy';
     svg.appendChild(yAxisLabel);
 }
 

--- a/script.js
+++ b/script.js
@@ -1611,7 +1611,7 @@ function updateCalibrationChart() {
         xLabel.setAttribute('y', height - paddingBottom + 15);
         xLabel.setAttribute('text-anchor', 'end');
         xLabel.setAttribute('font-size', '10');
-        xLabel.setAttribute('transform', `rotate(-45 ${x} ${height - paddingBottom + 15})`);
+        xLabel.setAttribute('transform', `rotate(-45 ${x + 2} ${height - paddingBottom + 20})`);
         xLabel.textContent = `${i}%`;
         svg.appendChild(xLabel);
 
@@ -1625,7 +1625,7 @@ function updateCalibrationChart() {
 
         const yLabel = document.createElementNS(ns, 'text');
         yLabel.setAttribute('x', paddingLeft - 8);
-        yLabel.setAttribute('y', y + 3);
+        yLabel.setAttribute('y', y + 6);
         yLabel.setAttribute('text-anchor', 'end');
         yLabel.setAttribute('font-size', '10');
         yLabel.textContent = `${i}%`;

--- a/script.js
+++ b/script.js
@@ -742,6 +742,8 @@ const medianFirstGuessText = document.getElementById('median-first-guess-text');
 const firstGuessPercentileText = document.getElementById('first-guess-percentile-text');
 const calibrationCheckbox = document.getElementById('prob-calibration-checkbox');
 const firstGuessCheckbox = document.getElementById('first-guess-checkbox');
+const calibrationChart = document.getElementById('calibration-chart');
+const calibrationTooltip = document.getElementById('calibration-tooltip');
 
 // Initialize game
 function initGame() {
@@ -1503,10 +1505,25 @@ function updateStatsDisplay() {
     updateCalibrationChart();
 }
 
+function showCalibrationTooltip(evt, sampleSize, declared, actual) {
+    if (!calibrationTooltip) return;
+    const x = (evt.clientX || 0) + 10;
+    const y = (evt.clientY || 0) + 10;
+    calibrationTooltip.style.left = `${x}px`;
+    calibrationTooltip.style.top = `${y}px`;
+    calibrationTooltip.innerHTML = `Sample Size: ${sampleSize}<br>Declared: ${declared}%<br>Actual: ${Math.round(actual)}%`;
+    calibrationTooltip.style.display = 'block';
+}
+
+function hideCalibrationTooltip() {
+    if (calibrationTooltip) calibrationTooltip.style.display = 'none';
+}
+
 function updateCalibrationChart() {
-    const svg = document.getElementById('calibration-chart');
+    const svg = calibrationChart;
     if (!svg) return;
 
+    hideCalibrationTooltip();
     while (svg.firstChild) svg.removeChild(svg.firstChild);
 
     const width = svg.viewBox.baseVal?.width || svg.width.baseVal.value || 300;
@@ -1625,6 +1642,13 @@ function updateCalibrationChart() {
         circle.setAttribute('cy', y);
         circle.setAttribute('r', 3);
         circle.setAttribute('fill', '#3498db');
+        circle.addEventListener('mouseenter', (e) => showCalibrationTooltip(e, bin.total, (i + 1) * 10, ratio * 100));
+        circle.addEventListener('mouseleave', hideCalibrationTooltip);
+        circle.addEventListener('click', (e) => showCalibrationTooltip(e, bin.total, (i + 1) * 10, ratio * 100));
+        circle.addEventListener('touchstart', (e) => {
+            const t = e.touches[0];
+            if (t) showCalibrationTooltip(t, bin.total, (i + 1) * 10, ratio * 100);
+        }, { passive: true });
         svg.appendChild(circle);
     });
 
@@ -2682,5 +2706,13 @@ function setupEventListeners() {
     }
 }
 
+if (calibrationChart) {
+    calibrationChart.addEventListener('mouseleave', hideCalibrationTooltip);
+}
+
+document.addEventListener('click', (e) => {
+    if (!e.target.closest('#calibration-chart')) hideCalibrationTooltip();
+});
+
 // Initialize the game when the page loads
-document.addEventListener('DOMContentLoaded', initGame); 
+document.addEventListener('DOMContentLoaded', initGame);

--- a/script.js
+++ b/script.js
@@ -741,6 +741,7 @@ const shareStatsBtn = document.getElementById('share-stats-btn');
 const medianFirstGuessText = document.getElementById('median-first-guess-text');
 const firstGuessPercentileText = document.getElementById('first-guess-percentile-text');
 const calibrationCheckbox = document.getElementById('prob-calibration-checkbox');
+const firstGuessCheckbox = document.getElementById('first-guess-checkbox');
 
 // Initialize game
 function initGame() {
@@ -1035,7 +1036,7 @@ function submitGuess() {
     if (calibrationEnabled && confidenceInput) {
         const confPercent = isNaN(confidenceValue) ? null : Math.max(0, Math.min(100, confidenceValue));
         if (confPercent !== null) {
-            stats.calibrationData.push({ confidence: confPercent / 100, correct: isCorrect });
+            stats.calibrationData.push({ confidence: confPercent / 100, correct: isCorrect, guessNumber: currentGuess });
             saveStats();
         }
         confidenceInput.value = '50';
@@ -1511,7 +1512,11 @@ function updateCalibrationChart() {
     const width = svg.viewBox.baseVal?.width || svg.width.baseVal.value || 300;
     const height = svg.viewBox.baseVal?.height || svg.height.baseVal.value || 200;
 
-    const data = stats.calibrationData || [];
+    const firstOnly = firstGuessCheckbox && firstGuessCheckbox.checked;
+    let data = stats.calibrationData || [];
+    if (firstOnly) {
+        data = data.filter(d => d.guessNumber === 1);
+    }
     if (data.length === 0) {
         const text = document.createElementNS('http://www.w3.org/2000/svg', 'text');
         text.setAttribute('x', 10);
@@ -2533,6 +2538,12 @@ function setupEventListeners() {
     if (calibrationCheckbox) {
         calibrationCheckbox.addEventListener('change', (e) => {
             setCalibrationEnabled(e.target.checked);
+        });
+    }
+
+    if (firstGuessCheckbox) {
+        firstGuessCheckbox.addEventListener('change', () => {
+            updateCalibrationChart();
         });
     }
     

--- a/script.js
+++ b/script.js
@@ -1586,8 +1586,9 @@ function updateCalibrationChart() {
         const xLabel = document.createElementNS(ns, 'text');
         xLabel.setAttribute('x', x);
         xLabel.setAttribute('y', height - paddingBottom + 15);
-        xLabel.setAttribute('text-anchor', 'middle');
+        xLabel.setAttribute('text-anchor', 'start');
         xLabel.setAttribute('font-size', '10');
+        xLabel.setAttribute('transform', `rotate(45 ${x} ${height - paddingBottom + 15})`);
         xLabel.textContent = `${i}%`;
         svg.appendChild(xLabel);
 
@@ -1608,24 +1609,11 @@ function updateCalibrationChart() {
         svg.appendChild(yLabel);
     }
 
-    // Calibration curve
-    const points = [];
+    // Calibration points
     bins.forEach((bin, i) => {
+        if (!bin.total) return;
         const x = paddingLeft + ((i + 1) / 10) * plotWidth;
-        const ratio = bin.total ? (bin.correct / bin.total) : 0;
-        const y = height - paddingBottom - ratio * plotHeight;
-        points.push(`${x},${y}`);
-    });
-
-    const polyline = document.createElementNS(ns, 'polyline');
-    polyline.setAttribute('points', points.join(' '));
-    polyline.setAttribute('fill', 'none');
-    polyline.setAttribute('stroke', '#3498db');
-    svg.appendChild(polyline);
-
-    bins.forEach((bin, i) => {
-        const x = paddingLeft + ((i + 1) / 10) * plotWidth;
-        const ratio = bin.total ? (bin.correct / bin.total) : 0;
+        const ratio = bin.correct / bin.total;
         const y = height - paddingBottom - ratio * plotHeight;
         const circle = document.createElementNS(ns, 'circle');
         circle.setAttribute('cx', x);

--- a/styles.css
+++ b/styles.css
@@ -582,6 +582,10 @@ button#stats-btn {
 
 .calibration-options {
     margin-bottom: 10px;
+    font-size: 0.7rem;
+    display: flex;
+    flex-flow: column;
+    gap: 10px;
 }
 
 .chart-tooltip {
@@ -631,14 +635,16 @@ button#stats-btn {
 }
 
 #confidence-input {
-    width: 60px;
+    margin: 0 8px 0 0;
+    width: 72px;
+    padding: 18.5px 0;
     background: none;
     border: none;
+    border-left: 2px solid #eaecf0;
     font-size: 0.8rem;
     font-family: 'Press Start 2P', monospace;
     outline: none;
     text-align: right;
-    padding: 18.5px 10px 18.5px 0;
     display: none;
 }
 

--- a/styles.css
+++ b/styles.css
@@ -653,8 +653,7 @@ button#stats-btn {
 }
 
 #confidence-input {
-    margin: 0 8px 0 0;
-    width: 72px;
+    margin: 0 10px 0 0;
     height: 100%;
     padding: 18.5px 0;
     background: none;

--- a/styles.css
+++ b/styles.css
@@ -588,6 +588,16 @@ button#stats-btn {
     gap: 10px;
 }
 
+.calibration-note {
+    font-size: 0.7rem;
+    margin-bottom: 8px;
+}
+
+.calibration-description {
+    font-size: 0.625rem;
+    margin-top: 8px;
+}
+
 .calibration-chart-wrapper {
     overflow-x: auto;
 }
@@ -644,11 +654,13 @@ button#stats-btn {
 
 #confidence-input {
     margin: 0 8px 0 0;
-    width: 70px;
+    width: 72px;
+    height: 100%;
     padding: 18.5px 0;
     background: none;
     border: none;
     border-left: 2px solid #eaecf0;
+    border-radius: 0;
     font-size: 0.8rem;
     font-family: 'Press Start 2P', monospace;
     outline: none;

--- a/styles.css
+++ b/styles.css
@@ -588,6 +588,14 @@ button#stats-btn {
     gap: 10px;
 }
 
+.calibration-chart-wrapper {
+    overflow-x: auto;
+}
+
+#calibration-chart {
+    display: block;
+}
+
 .chart-tooltip {
     position: fixed;
     background: rgba(0, 0, 0, 0.8);
@@ -783,8 +791,8 @@ button#stats-btn {
 .stats-grid {
     display: grid;
     grid-template-columns: repeat(3, 1fr);
-    gap: 15px;
-    margin: 25px 0;
+    gap: 12px 8px;
+    margin: 8px 0;
 }
 
 .stats-grid-accordion {
@@ -814,7 +822,7 @@ button#stats-btn {
 
 /* Guess Distribution */
 .guess-distribution {
-    margin: 25px 0;
+    margin: 8px 0 12px;
 }
 
 .guess-distribution h3 {
@@ -853,7 +861,7 @@ button#stats-btn {
 
 .dist-bar {
     height: 100%;
-    background-color: #27ae60;
+    background-color: #3498db;
     border-radius: 10px;
     transition: width 0.3s ease;
     min-width: 20px;

--- a/styles.css
+++ b/styles.css
@@ -584,6 +584,19 @@ button#stats-btn {
     margin-bottom: 10px;
 }
 
+.chart-tooltip {
+    position: fixed;
+    background: rgba(0, 0, 0, 0.8);
+    color: #fff;
+    padding: 4px 8px;
+    border-radius: 4px;
+    font-size: 0.625rem;
+    pointer-events: none;
+    display: none;
+    z-index: 1000;
+    white-space: nowrap;
+}
+
 .input-row {
     display: flex;
     align-items: center;

--- a/styles.css
+++ b/styles.css
@@ -629,7 +629,6 @@ button#stats-btn {
     height: 54px;
     display: flex;
     align-items: center;
-    gap: 8px;
     border-radius: 15px;
     flex: 1;
     border: 2px solid #eaecf0;
@@ -644,7 +643,7 @@ button#stats-btn {
     outline: none;
     min-width: 0;
     width: 100%;
-    padding: 18.5px 15px;
+    padding: 18.5px 0px 18.5px 15px;
     border-radius: 15px;
 }
 
@@ -660,10 +659,11 @@ button#stats-btn {
     border: none;
     border-left: 2px solid #eaecf0;
     border-radius: 0;
+    color: #333;
     font-size: 0.8rem;
     font-family: 'Press Start 2P', monospace;
     outline: none;
-    text-align: right;
+    text-align: center;
     display: none;
 }
 

--- a/styles.css
+++ b/styles.css
@@ -588,14 +588,14 @@ button#stats-btn {
     gap: 10px;
 }
 
-.calibration-note {
+.modal-content p.calibration-note {
     font-size: 0.7rem;
-    margin-bottom: 8px;
+    margin: 16px 0 8px;
 }
 
-.calibration-description {
+.modal-content p.calibration-description {
     font-size: 0.625rem;
-    margin-top: 8px;
+    margin: 8px 0 0;
 }
 
 .calibration-chart-wrapper {
@@ -866,7 +866,7 @@ button#stats-btn {
 .dist-bar-container {
     flex: 1;
     height: 20px;
-    background-color: #e0e0e0;
+    background-color: #f5f5f5;
     border-radius: 10px;
     overflow: hidden;
 }

--- a/styles.css
+++ b/styles.css
@@ -580,6 +580,10 @@ button#stats-btn {
     margin-top: 20px;
 }
 
+.calibration-options {
+    margin-bottom: 10px;
+}
+
 .input-row {
     display: flex;
     align-items: center;

--- a/styles.css
+++ b/styles.css
@@ -636,7 +636,7 @@ button#stats-btn {
 
 #confidence-input {
     margin: 0 8px 0 0;
-    width: 72px;
+    width: 70px;
     padding: 18.5px 0;
     background: none;
     border: none;
@@ -745,6 +745,7 @@ button#stats-btn {
     align-items: center;
     justify-content: space-between;
     cursor: pointer;
+    line-height: 1.4;
 }
 
 .accordion-panel {

--- a/styles.css
+++ b/styles.css
@@ -613,6 +613,18 @@ button#stats-btn {
     color: #999;
 }
 
+#confidence-input {
+    width: 60px;
+    background: none;
+    border: none;
+    font-size: 0.8rem;
+    font-family: 'Press Start 2P', monospace;
+    outline: none;
+    text-align: right;
+    padding: 18.5px 10px 18.5px 0;
+    display: none;
+}
+
 .submit-btn {
     width: 110px;
     height: 54px;


### PR DESCRIPTION
## Summary
- Add optional probability calibration setting via checkbox in How to Play modal
- Allow entering guess confidence and log calibration data per guess
- Show calibration curve in stats modal accordion
- Restrict confidence selection to preset values with default 50% and include 100%
- Replace canvas calibration chart with SVG labeled at 10% intervals for both axes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b8112e98948329a6a87ee41d5eac8b