### PR TITLE
fix: persist confidence selection on mobile

### DIFF
--- a/script.js
+++ b/script.js
@@ -1757,9 +1757,10 @@ function setCalibrationEnabled(enabled) {
 
 function updateConfidenceInputVisibility() {
     if (confidenceInput) {
+        const prevValue = confidenceInput.value;
         confidenceInput.style.display = calibrationEnabled ? 'block' : 'none';
         if (calibrationEnabled) {
-            confidenceInput.value = '50';
+            confidenceInput.value = prevValue || '50';
         } else {
             confidenceInput.value = '';
         }


### PR DESCRIPTION
## Summary
- keep confidence dropdown value when mobile viewport resizes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b99cdc82b48329a1a83e29cef22cde