### PR TITLE
fix: persist confidence selection on mobile

### DIFF
--- a/script.js
+++ b/script.js
@@ -1757,9 +1757,10 @@ function setCalibrationEnabled(enabled) {
 
 function updateConfidenceInputVisibility() {
     if (confidenceInput) {
+        const prevValue = confidenceInput.value;
         confidenceInput.style.display = calibrationEnabled ? 'block' : 'none';
         if (calibrationEnabled) {
-            confidenceInput.value = '50';
+            confidenceInput.value = prevValue || '50';
         } else {
             confidenceInput.value = '';
         }

--- a/styles.css
+++ b/styles.css
@@ -655,7 +655,14 @@ button#stats-btn {
     height: 100%;
     width: 72px;
     padding: 18.5px 0;
-    background: none;
+    padding-right: 8px;
+    -webkit-appearance: none;
+    appearance: none;
+    background-color: transparent;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='8' height='5' viewBox='0 0 8 5'%3E%3Cpath fill='none' stroke='%23333' stroke-width='1.5' d='M1 1l3 3 3-3'/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-position: right 4px center;
+    background-size: 8px 5px;
     border: none;
     border-left: 2px solid #eaecf0;
     border-radius: 0;
@@ -665,7 +672,11 @@ button#stats-btn {
     outline: none;
     text-align: right;
     gap: 0px;
-    padding-inline: 0;
+    padding-inline-start: 0;
+    display: none;
+}
+
+#confidence-input::-ms-expand {
     display: none;
 }
 


### PR DESCRIPTION
## Summary
- keep confidence dropdown value when mobile viewport resizes
- reduce gap between confidence value and dropdown arrow on iOS

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b99cdc82b48329a1a83e29cef22cde