### PR TITLE
fix: persist confidence selection on mobile

### DIFF
--- a/script.js
+++ b/script.js
@@ -720,6 +720,10 @@ const guessesContainer = document.getElementById('guesses-container');
 const guessInput = document.getElementById('guess-input');
 const confidenceInput = document.getElementById('confidence-input');
 const submitBtn = document.getElementById('submit-btn');
+const sendIcon = `\
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+  <path d="M2 21L23 12L2 3v7l12 2L2 14v7z"/>
+</svg>`;
 const inputSection = document.getElementById('input-section');
 const newGameSection = document.getElementById('new-game-section');
 const newGameBtnInline = document.getElementById('new-game-btn-inline');
@@ -1053,7 +1057,7 @@ function submitGuess() {
             stats.calibrationData.push({ confidence: confPercent / 100, correct: isCorrect, guessNumber: currentGuess });
             saveStats();
         }
-        confidenceInput.value = '50';
+        
     }
     
     // Save current game state after each guess
@@ -1757,9 +1761,10 @@ function setCalibrationEnabled(enabled) {
 
 function updateConfidenceInputVisibility() {
     if (confidenceInput) {
+        const prevValue = confidenceInput.value;
         confidenceInput.style.display = calibrationEnabled ? 'block' : 'none';
         if (calibrationEnabled) {
-            confidenceInput.value = '50';
+            confidenceInput.value = prevValue || '50';
         } else {
             confidenceInput.value = '';
         }
@@ -1767,7 +1772,7 @@ function updateConfidenceInputVisibility() {
     if (submitBtn) {
         if (calibrationEnabled && isSmallDevice()) {
             submitBtn.style.width = '54px';
-            submitBtn.textContent = '>';
+            submitBtn.innerHTML = sendIcon;
         } else {
             submitBtn.style.width = '';
             submitBtn.textContent = 'Submit';

--- a/styles.css
+++ b/styles.css
@@ -653,9 +653,10 @@ button#stats-btn {
 #confidence-input {
     margin: 0 10px 0 0;
     height: 100%;
-    width: 72px;
+    width: 60px;
     padding: 18.5px 0;
-    background: none;
+    padding-right: 2px;
+    -webkit-padding-end: 2px;
     border: none;
     border-left: 2px solid #eaecf0;
     border-radius: 0;
@@ -664,8 +665,7 @@ button#stats-btn {
     font-family: 'Press Start 2P', monospace;
     outline: none;
     text-align: right;
-    gap: 0px;
-    padding-inline: 0;
+    padding-inline-start: 0;
     display: none;
 }
 
@@ -682,10 +682,18 @@ button#stats-btn {
     cursor: pointer;
     transition: background-color 0.2s;
     white-space: nowrap;
+    display: flex;
+    align-items: center;
+    justify-content: center;
 }
 
 .submit-btn:hover {
     background-color: #2e86c1;
+}
+
+.submit-btn svg {
+    width: 24px;
+    height: 24px;
 }
 
 .submit-btn:disabled {

--- a/styles.css
+++ b/styles.css
@@ -656,8 +656,8 @@ button#stats-btn {
     width: 72px;
     padding: 18.5px 0;
     background: none;
-    padding-right: 2px;
-    -webkit-padding-end: 2px;
+    padding-right: 0px;
+    -webkit-padding-end: 0px;
     border: none;
     border-left: 2px solid #eaecf0;
     border-radius: 0;

--- a/styles.css
+++ b/styles.css
@@ -653,8 +653,9 @@ button#stats-btn {
 #confidence-input {
     margin: 0 10px 0 0;
     height: 100%;
-    width: 60px;
+    width: 72px;
     padding: 18.5px 0;
+    background: none;
     padding-right: 2px;
     -webkit-padding-end: 2px;
     border: none;


### PR DESCRIPTION
## Summary
- keep user-selected confidence when submitting guesses
- restore iOS dropdown arrow and tighten spacing
- show send icon on mobile submit button

## Testing
- `npm test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b99cdc82b48329a1a83e29cef22cde