### PR TITLE
Add dismissible calibration mode banner

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,11 @@
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
 </head>
 <body>
+        <div id="calibration-banner" class="calibration-banner">
+            <span class="banner-text">Enable probability calibration mode?</span>
+            <button id="enable-calibration-btn" class="banner-action">Enable</button>
+            <button id="calibration-banner-close" class="banner-close" aria-label="Close">&times;</button>
+        </div>
         <header class="game-header">
             <div class="header-left">
                 <img src="https://upload.wikimedia.org/wikipedia/commons/6/6f/Photograph_of_Enrico_Fermi_-_NARA_-_595043.gif" alt="Enrico Fermi" class="fermi-logo">

--- a/script.js
+++ b/script.js
@@ -758,6 +758,9 @@ const firstGuessCheckbox = document.getElementById('first-guess-checkbox');
 const calibrationChart = document.getElementById('calibration-chart');
 const calibrationTooltip = document.getElementById('calibration-tooltip');
 const calibrationNote = document.querySelector('.calibration-note');
+const calibrationBanner = document.getElementById('calibration-banner');
+const enableCalibrationBtn = document.getElementById('enable-calibration-btn');
+const calibrationBannerClose = document.getElementById('calibration-banner-close');
 
 // Initialize game
 function initGame() {
@@ -765,8 +768,9 @@ function initGame() {
     initSupabase();
 
     loadStats();
-    loadCompletedQuestions();
+   loadCompletedQuestions();
     loadCalibrationSetting();
+    initCalibrationBanner();
 
     // If URL has a specific question date, navigate to it first
     let navigatedFromURL = false;
@@ -1748,6 +1752,7 @@ function loadCalibrationSetting() {
         cb.checked = calibrationEnabled;
     });
     updateConfidenceInputVisibility();
+    updateCalibrationBannerVisibility();
 }
 
 function setCalibrationEnabled(enabled) {
@@ -1757,6 +1762,7 @@ function setCalibrationEnabled(enabled) {
         cb.checked = enabled;
     });
     updateConfidenceInputVisibility();
+    updateCalibrationBannerVisibility();
 }
 
 function updateConfidenceInputVisibility() {
@@ -1778,6 +1784,30 @@ function updateConfidenceInputVisibility() {
             submitBtn.textContent = 'Submit';
         }
     }
+}
+
+function updateCalibrationBannerVisibility() {
+    if (!calibrationBanner) return;
+    const closed = localStorage.getItem('fermiCalibrationBannerClosed') === 'true';
+    calibrationBanner.style.display = (!closed && !calibrationEnabled) ? 'block' : 'none';
+}
+
+function initCalibrationBanner() {
+    if (!calibrationBanner) return;
+    if (calibrationBannerClose) {
+        calibrationBannerClose.addEventListener('click', () => {
+            calibrationBanner.style.display = 'none';
+            localStorage.setItem('fermiCalibrationBannerClosed', 'true');
+        });
+    }
+    if (enableCalibrationBtn) {
+        enableCalibrationBtn.addEventListener('click', () => {
+            setCalibrationEnabled(true);
+            localStorage.setItem('fermiCalibrationBannerClosed', 'true');
+            calibrationBanner.style.display = 'none';
+        });
+    }
+    updateCalibrationBannerVisibility();
 }
 
 // Save current game state to localStorage and Supabase (per question)

--- a/styles.css
+++ b/styles.css
@@ -1051,3 +1051,28 @@ button#stats-btn {
 .shake {
     animation: shake 0.5s ease-in-out;
 }
+
+/* Calibration banner */
+.calibration-banner {
+    display: none;
+    background-color: #fff3cd;
+    color: #333;
+    padding: 10px 40px 10px 10px;
+    text-align: center;
+    position: relative;
+    border: 1px solid #ffeeba;
+}
+
+.calibration-banner .banner-action {
+    margin-left: 10px;
+}
+
+.calibration-banner .banner-close {
+    position: absolute;
+    right: 10px;
+    top: 5px;
+    background: none;
+    border: none;
+    font-size: 16px;
+    cursor: pointer;
+}


### PR DESCRIPTION
## Summary
- Add alert banner with enable button to turn on probability calibration mode
- Persist banner dismissal in localStorage and hide when calibration is active
- Style banner for visibility and add JS logic for showing/hiding

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68b9cc608cd4832989aaed5e9a2f1946