### PR TITLE
Use accordion for mobile hint toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,7 +80,9 @@
         <!-- Hint (hidden by default) -->
         <div class="hint-container" id="hint-container" style="display: none;">
             <button id="hint-modal-btn" class="hint-link" aria-controls="hint-text" aria-expanded="false">Show hint <span class="arrow">></span></button>
-            <div class="hint-text" id="hint-text"></div>
+            <div class="hint-text" id="hint-text">
+                <span class="hint-label">Hint: </span><span id="hint-body"></span>
+            </div>
         </div>
 
         <!-- Game Result (hidden by default) -->

--- a/index.html
+++ b/index.html
@@ -79,8 +79,8 @@
 
         <!-- Hint (hidden by default) -->
         <div class="hint-container" id="hint-container" style="display: none;">
+            <button id="hint-modal-btn" class="hint-link" aria-controls="hint-text" aria-expanded="false">Show hint <span class="arrow">></span></button>
             <div class="hint-text" id="hint-text"></div>
-            <button id="hint-modal-btn" class="hint-link" aria-controls="hint-modal" aria-haspopup="dialog">Show hint <span class="arrow">></span></button>
         </div>
 
         <!-- Game Result (hidden by default) -->
@@ -166,14 +166,6 @@
             </div>
         </div>
 
-        <!-- Hint Modal -->
-        <div class="modal" id="hint-modal">
-            <div class="modal-content">
-                <h2>Hint</h2>
-                <p id="hint-modal-text"></p>
-                <button id="close-hint-btn" class="close-btn">Close</button>
-            </div>
-        </div>
 
         <!-- Source/Explanation Modal -->
         <div class="modal" id="source-modal">

--- a/script.js
+++ b/script.js
@@ -1299,8 +1299,8 @@ function triggerConfetti(durationMs = 1200, particleCount = 80) {
 // Show hint after 2rd guess
 function showHint() {
     if (currentQuestion.hint) {
-        // Inline hint text always includes a "Hint: " prefix (it's hidden on mobile via CSS)
-        hintText.textContent = `Hint: ${currentQuestion.hint}`;
+        // Display only the hint text; "Hint:" label is handled via CSS on desktop
+        hintText.textContent = currentQuestion.hint;
         guessCounter.style.display = 'none';
         hintContainer.style.display = 'block';
         hintContainer.classList.remove('open');

--- a/script.js
+++ b/script.js
@@ -740,11 +740,8 @@ const questionsModal = document.getElementById('questions-modal');
 const strategyModal = document.getElementById('strategy-modal');
 const strategyTipsBtn = document.getElementById('strategy-tips-btn');
 const closeStrategyBtn = document.getElementById('close-strategy-btn');
-// Hint modal elements
-const hintModal = document.getElementById('hint-modal');
+// Hint elements
 const hintModalBtn = document.getElementById('hint-modal-btn');
-const hintModalText = document.getElementById('hint-modal-text');
-const closeHintBtn = document.getElementById('close-hint-btn');
 const questionsList = document.getElementById('questions-list');
 const closeHelpBtn = document.getElementById('close-help-btn');
 const closeStatsBtn = document.getElementById('close-stats-btn');
@@ -1306,17 +1303,21 @@ function showHint() {
         hintText.textContent = `Hint: ${currentQuestion.hint}`;
         guessCounter.style.display = 'none';
         hintContainer.style.display = 'block';
-        triggerShake(hintContainer);
-        // Also update modal hint text
-        if (hintModalText) {
-            hintModalText.textContent = currentQuestion.hint;
+        hintContainer.classList.remove('open');
+        if (hintModalBtn) {
+            hintModalBtn.setAttribute('aria-expanded', 'false');
         }
+        triggerShake(hintContainer);
     }
 }
 
 // Hide hint
 function hideHint() {
     hintContainer.style.display = 'none';
+    hintContainer.classList.remove('open');
+    if (hintModalBtn) {
+        hintModalBtn.setAttribute('aria-expanded', 'false');
+    }
 }
 
 // End the game
@@ -2553,14 +2554,17 @@ function setupEventListeners() {
         strategyTipsBtn.addEventListener('click', showHelp);
     }
 
-    // Hint modal trigger (mobile)
-    if (hintModalBtn && hintModal) {
+    // Hint accordion toggle (mobile)
+    if (hintModalBtn && hintContainer) {
         hintModalBtn.addEventListener('click', () => {
-            // Ensure latest hint is shown
-            if (currentQuestion && currentQuestion.hint && hintModalText) {
-                hintModalText.textContent = currentQuestion.hint;
+            const isOpen = hintContainer.classList.contains('open');
+            if (isOpen) {
+                hintContainer.classList.remove('open');
+                hintModalBtn.setAttribute('aria-expanded', 'false');
+            } else {
+                hintContainer.classList.add('open');
+                hintModalBtn.setAttribute('aria-expanded', 'true');
             }
-            hintModal.style.display = 'block';
         });
     }
     
@@ -2708,16 +2712,13 @@ function setupEventListeners() {
     if (closeStrategyBtn) {
         closeStrategyBtn.addEventListener('click', () => closeModal(strategyModal));
     }
-    if (closeHintBtn) {
-        closeHintBtn.addEventListener('click', () => closeModal(hintModal));
-    }
 
     // Share buttons
     shareBtn.addEventListener('click', shareGame);
     shareStatsBtn.addEventListener('click', shareStats);
         
     // Close modals when clicking outside (desktop + mobile)
-    [helpModal, statsModal, questionsModal, strategyModal, hintModal, sourceModal].forEach(modal => {
+    [helpModal, statsModal, questionsModal, strategyModal, sourceModal].forEach(modal => {
         ['click', 'touchend'].forEach(event => {
             modal.addEventListener(event, e => e.target === modal && closeModal(modal));
         });

--- a/script.js
+++ b/script.js
@@ -706,6 +706,7 @@ const currentStreakDisplay = document.getElementById('current-streak-display');
 const guessCounter = document.getElementById('guess-counter');
 const hintContainer = document.getElementById('hint-container');
 const hintText = document.getElementById('hint-text');
+const hintBody = document.getElementById('hint-body');
 const questionMeta = document.getElementById('question-meta');
 const streakInline = document.getElementById('streak-inline');
 const sourceBtn = document.getElementById('source-btn');
@@ -1299,8 +1300,7 @@ function triggerConfetti(durationMs = 1200, particleCount = 80) {
 // Show hint after 2rd guess
 function showHint() {
     if (currentQuestion.hint) {
-        // Display only the hint text; "Hint:" label is handled via CSS on desktop
-        hintText.textContent = currentQuestion.hint;
+        hintBody.textContent = currentQuestion.hint;
         guessCounter.style.display = 'none';
         hintContainer.style.display = 'block';
         hintContainer.classList.remove('open');

--- a/styles.css
+++ b/styles.css
@@ -391,6 +391,15 @@ button#stats-btn {
     transform: rotate(90deg);
 }
 
+.hint-container.open #hint-text {
+    display: block;
+    margin-top: 12px;
+}
+
+.hint-container.open .hint-link .arrow {
+    transform: rotate(270deg);
+}
+
 /* Game Result */
 .game-result {
     text-align: center;

--- a/styles.css
+++ b/styles.css
@@ -373,6 +373,10 @@ button#stats-btn {
     font-size: 0.85rem;
 }
 
+#hint-text::before {
+    content: "Hint: ";
+}
+
 /* Hint accordion trigger (mobile) */
 .hint-link {
     display: none;
@@ -1004,6 +1008,9 @@ button#stats-btn {
     /* On mobile, hide inline hint text and show the button */
     #hint-text {
         display: none;
+    }
+    #hint-text::before {
+        content: '';
     }
     .hint-link {
         display: inline;

--- a/styles.css
+++ b/styles.css
@@ -373,10 +373,6 @@ button#stats-btn {
     font-size: 0.85rem;
 }
 
-.hint-label {
-    font-weight: bold;
-}
-
 /* Hint accordion trigger (mobile) */
 .hint-link {
     display: none;
@@ -1017,7 +1013,8 @@ button#stats-btn {
     }
     .hint-container.open #hint-text {
         display: block;
-        padding: 18.75px;
+        padding: 14px;
+        font-size: 0.8rem;
         border-top: 2px solid #e9ecef;
         background: white;
     }

--- a/styles.css
+++ b/styles.css
@@ -373,8 +373,8 @@ button#stats-btn {
     font-size: 0.85rem;
 }
 
-#hint-text::before {
-    content: "Hint: ";
+.hint-label {
+    font-weight: bold;
 }
 
 /* Hint accordion trigger (mobile) */
@@ -1009,8 +1009,8 @@ button#stats-btn {
     #hint-text {
         display: none;
     }
-    #hint-text::before {
-        content: '';
+    .hint-label {
+        display: none;
     }
     .hint-link {
         display: inline;

--- a/styles.css
+++ b/styles.css
@@ -365,25 +365,30 @@ button#stats-btn {
 }
 
 /* Hint Container */
+
 .hint-container {
     text-align: center;
     margin-bottom: 20px;
     line-height: 1.5;
     font-size: 0.85rem;
-}
-
-/* Hint modal trigger button (mobile) */
-.hint-link {
-    display: none;
     background: white;
     border: 2px solid #e9ecef;
+    border-radius: 15px;
+    overflow: hidden;
+}
+
+/* Hint accordion trigger (mobile) */
+.hint-link {
+    display: none;
+    background: transparent;
+    border: none;
     font-family: 'Press Start 2P', monospace;
     font-size: 0.82rem;
     padding: 18.75px;
     width: 100%;
-    border-radius: 15px;
     color: #333;
     -webkit-tap-highlight-color: transparent;
+    cursor: pointer;
 }
 
 .hint-link .arrow {
@@ -393,7 +398,9 @@ button#stats-btn {
 
 .hint-container.open #hint-text {
     display: block;
-    margin-top: 12px;
+    padding: 18.75px;
+    border-top: 2px solid #e9ecef;
+    background: white;
 }
 
 .hint-container.open .hint-link .arrow {

--- a/styles.css
+++ b/styles.css
@@ -371,10 +371,6 @@ button#stats-btn {
     margin-bottom: 20px;
     line-height: 1.5;
     font-size: 0.85rem;
-    background: white;
-    border: 2px solid #e9ecef;
-    border-radius: 15px;
-    overflow: hidden;
 }
 
 /* Hint accordion trigger (mobile) */
@@ -394,17 +390,6 @@ button#stats-btn {
 .hint-link .arrow {
     display: inline-block;
     transform: rotate(90deg);
-}
-
-.hint-container.open #hint-text {
-    display: block;
-    padding: 18.75px;
-    border-top: 2px solid #e9ecef;
-    background: white;
-}
-
-.hint-container.open .hint-link .arrow {
-    transform: rotate(270deg);
 }
 
 /* Game Result */
@@ -988,6 +973,12 @@ button#stats-btn {
     .hint-container {
         margin-bottom: 18px;
     }
+    .hint-container {
+        background: white;
+        border: 2px solid #e9ecef;
+        border-radius: 15px;
+        overflow: hidden;
+    }
     .game-result {
         border: 2px solid #e8ecee;
         border-radius: 16px;
@@ -1016,6 +1007,15 @@ button#stats-btn {
     }
     .hint-link {
         display: inline;
+    }
+    .hint-container.open #hint-text {
+        display: block;
+        padding: 18.75px;
+        border-top: 2px solid #e9ecef;
+        background: white;
+    }
+    .hint-container.open .hint-link .arrow {
+        transform: rotate(270deg);
     }
     /* On mobile, hide the streak label and show strategy link */
     #current-streak-display {


### PR DESCRIPTION
## Summary
- Replace hint modal with inline accordion to reveal hints below the button
- Toggle hint visibility via JavaScript instead of opening a modal
- Add CSS for accordion state and arrow rotation

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9ce1b29748329aa92fe5f97267509