### PR TITLE
Keep keyboard active during confidence selection and restore scroll

### DIFF
--- a/script.js
+++ b/script.js
@@ -2546,8 +2546,8 @@ function setupEventListeners() {
         }
     });
 
-    guessInput.addEventListener('blur', () => {
-        if (isSmallDevice() && document.activeElement !== confidenceInput) {
+    guessInput.addEventListener('blur', (e) => {
+        if (isSmallDevice() && e.relatedTarget !== confidenceInput) {
             window.scrollTo(0, guessInputScrollPos);
         }
     });

--- a/script.js
+++ b/script.js
@@ -729,6 +729,7 @@ const correctAnswer = document.getElementById('correct-answer');
 const guessesContainer = document.getElementById('guesses-container');
 const guessInput = document.getElementById('guess-input');
 const confidenceInput = document.getElementById('confidence-input');
+let guessInputScrollPos = 0;
 const submitBtn = document.getElementById('submit-btn');
 const sendIcon = `\
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
@@ -2537,7 +2538,20 @@ function setupEventListeners() {
             submitGuess();
         }
     });
-    
+
+    // Preserve scroll position while keyboard is open (mobile)
+    guessInput.addEventListener('focus', () => {
+        if (isSmallDevice()) {
+            guessInputScrollPos = window.scrollY;
+        }
+    });
+
+    guessInput.addEventListener('blur', () => {
+        if (isSmallDevice() && document.activeElement !== confidenceInput) {
+            window.scrollTo(0, guessInputScrollPos);
+        }
+    });
+
     // Format input with commas as user types
     guessInput.addEventListener('input', (e) => {
         const input = e.target;
@@ -2551,6 +2565,15 @@ function setupEventListeners() {
             input.value = formattedValue;
         }
     });
+
+    // Keep keyboard open when selecting confidence on mobile
+    if (confidenceInput) {
+        confidenceInput.addEventListener('change', () => {
+            if (isSmallDevice()) {
+                setTimeout(() => guessInput.focus(), 0);
+            }
+        });
+    }
     
     // Help button
     helpBtn.addEventListener('click', showHelp);


### PR DESCRIPTION
## Summary
- Keep keyboard open on mobile by refocusing guess input when confidence changes
- Remember page position while typing and restore it once keyboard closes

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba983ee43c83298923681269c0e952