### PR TITLE
fix: avoid scroll restoration when focusing confidence selector

### DIFF
--- a/script.js
+++ b/script.js
@@ -2546,8 +2546,8 @@ function setupEventListeners() {
         }
     });
 
-    guessInput.addEventListener('blur', () => {
-        if (isSmallDevice() && document.activeElement !== confidenceInput) {
+    guessInput.addEventListener('blur', (e) => {
+        if (isSmallDevice() && e.relatedTarget !== confidenceInput) {
             window.scrollTo(0, guessInputScrollPos);
         }
     });


### PR DESCRIPTION
## Summary
- Avoid restoring scroll position when blur is caused by moving focus to the confidence selector

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba9a09946c8329938f8544d70d2447