### PR TITLE
Restore scroll on mobile without blocking submit

### DIFF
--- a/script.js
+++ b/script.js
@@ -2552,6 +2552,14 @@ function setupEventListeners() {
         }
     });
 
+    if (confidenceInput) {
+        confidenceInput.addEventListener('change', () => {
+            if (isSmallDevice()) {
+                guessInput.focus();
+            }
+        });
+    }
+
     // Format input with commas as user types
     guessInput.addEventListener('input', (e) => {
         const input = e.target;

--- a/script.js
+++ b/script.js
@@ -2548,7 +2548,13 @@ function setupEventListeners() {
 
     guessInput.addEventListener('blur', () => {
         if (isSmallDevice() && document.activeElement !== confidenceInput) {
-            setTimeout(() => window.scrollTo(0, guessInputScrollPos), 100);
+            setTimeout(() => {
+                window.scrollTo({
+                    top: guessInputScrollPos,
+                    left: 0,
+                    behavior: 'smooth'
+                });
+            }, 100);
         }
     });
 

--- a/script.js
+++ b/script.js
@@ -729,6 +729,7 @@ const correctAnswer = document.getElementById('correct-answer');
 const guessesContainer = document.getElementById('guesses-container');
 const guessInput = document.getElementById('guess-input');
 const confidenceInput = document.getElementById('confidence-input');
+let guessInputScrollPos = 0;
 const submitBtn = document.getElementById('submit-btn');
 const sendIcon = `\
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
@@ -2537,7 +2538,20 @@ function setupEventListeners() {
             submitGuess();
         }
     });
-    
+
+    // Preserve scroll position while keyboard is open (mobile)
+    guessInput.addEventListener('focus', () => {
+        if (isSmallDevice()) {
+            guessInputScrollPos = window.scrollY;
+        }
+    });
+
+    guessInput.addEventListener('blur', () => {
+        if (isSmallDevice() && document.activeElement !== confidenceInput) {
+            setTimeout(() => window.scrollTo(0, guessInputScrollPos), 100);
+        }
+    });
+
     // Format input with commas as user types
     guessInput.addEventListener('input', (e) => {
         const input = e.target;
@@ -2551,7 +2565,7 @@ function setupEventListeners() {
             input.value = formattedValue;
         }
     });
-    
+
     // Help button
     helpBtn.addEventListener('click', showHelp);
     

--- a/script.js
+++ b/script.js
@@ -2548,13 +2548,7 @@ function setupEventListeners() {
 
     guessInput.addEventListener('blur', () => {
         if (isSmallDevice() && document.activeElement !== confidenceInput) {
-            setTimeout(() => {
-                window.scrollTo({
-                    top: guessInputScrollPos,
-                    left: 0,
-                    behavior: 'smooth'
-                });
-            }, 100);
+            setTimeout(() => window.scrollTo(0, guessInputScrollPos), 100);
         }
     });
 


### PR DESCRIPTION
## Summary
- Restore prior scroll position after closing the keyboard without swallowing submit taps
- Remove automatic refocus on guess input when confidence changes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba983ee43c83298923681269c0e952