### PR TITLE
Smooth scroll restoration on guess input blur

### DIFF
--- a/script.js
+++ b/script.js
@@ -729,6 +729,7 @@ const correctAnswer = document.getElementById('correct-answer');
 const guessesContainer = document.getElementById('guesses-container');
 const guessInput = document.getElementById('guess-input');
 const confidenceInput = document.getElementById('confidence-input');
+let guessInputScrollPos = 0;
 const submitBtn = document.getElementById('submit-btn');
 const sendIcon = `\
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
@@ -2537,7 +2538,40 @@ function setupEventListeners() {
             submitGuess();
         }
     });
-    
+
+    // Preserve scroll position while keyboard is open (mobile)
+    guessInput.addEventListener('focus', () => {
+        if (isSmallDevice()) {
+            guessInputScrollPos = window.scrollY;
+        }
+    });
+
+    guessInput.addEventListener('blur', () => {
+        if (isSmallDevice() && document.activeElement !== confidenceInput) {
+            requestAnimationFrame(() => {
+                window.scrollTo({
+                    top: guessInputScrollPos,
+                    left: 0,
+                    behavior: 'smooth'
+                });
+            });
+        }
+    });
+
+    if (confidenceInput) {
+        let keepGuessFocus = false;
+        const trackGuessFocus = () => {
+            keepGuessFocus = document.activeElement === guessInput;
+        };
+        confidenceInput.addEventListener('mousedown', trackGuessFocus);
+        confidenceInput.addEventListener('touchstart', trackGuessFocus);
+        confidenceInput.addEventListener('click', () => {
+            if (keepGuessFocus && isSmallDevice()) {
+                guessInput.focus();
+            }
+        });
+    }
+
     // Format input with commas as user types
     guessInput.addEventListener('input', (e) => {
         const input = e.target;
@@ -2551,7 +2585,7 @@ function setupEventListeners() {
             input.value = formattedValue;
         }
     });
-    
+
     // Help button
     helpBtn.addEventListener('click', showHelp);
     


### PR DESCRIPTION
## Summary
- Restore viewport smoothly after guess input blur on small devices to match native keyboard scrolling
- Replace timeout with requestAnimationFrame so Submit taps register while keyboard is open
- Preserve guess field focus on confidence clicks only when it was previously active to keep keyboard open when desired

## Testing
- ❌ `npm test` (missing package.json)


------
https://chatgpt.com/codex/tasks/task_e_68ba983ee43c83298923681269c0e952