### PR TITLE
Keep mobile keyboard open after choosing confidence

### DIFF
--- a/script.js
+++ b/script.js
@@ -2554,55 +2554,19 @@ function setupEventListeners() {
 
     // Keep guess input focused when picking a confidence value so the keyboard stays open
     if (confidenceInput && guessInput) {
-        const useCustomMenu = () => isSmallDevice() && 'ontouchstart' in window;
-
-        if (useCustomMenu()) {
-            // Build a lightweight menu so selecting confidence doesn't blur the guess input
-            const menu = document.createElement('div');
-            menu.id = 'confidence-menu';
-            menu.style.display = 'none';
-
-            const hideMenu = () => {
-                menu.style.display = 'none';
-            };
-
-            Array.from(confidenceInput.options).forEach(opt => {
-                const btn = document.createElement('button');
-                btn.type = 'button';
-                btn.textContent = opt.textContent;
-                btn.addEventListener('click', () => {
-                    confidenceInput.value = opt.value;
-                    confidenceInput.dispatchEvent(new Event('change', { bubbles: true }));
-                    hideMenu();
-                    guessInput.focus();
-                });
-                menu.appendChild(btn);
-            });
-
-            document.body.appendChild(menu);
-
-            const showMenu = (e) => {
+        const handlePointerDown = (e) => {
+            if (isSmallDevice() && 'showPicker' in confidenceInput) {
                 e.preventDefault();
-                const rect = confidenceInput.getBoundingClientRect();
-                menu.style.left = `${rect.left + window.scrollX}px`;
-                menu.style.top = `${rect.bottom + window.scrollY}px`;
-                menu.style.display = 'block';
-                // Ensure guess input keeps focus so keyboard stays visible
-                guessInput.focus();
-            };
+                guessInput.focus({ preventScroll: true });
+                confidenceInput.showPicker();
+            }
+        };
 
-            confidenceInput.addEventListener('mousedown', showMenu);
-            confidenceInput.addEventListener('touchstart', showMenu);
-
-            document.addEventListener('click', (e) => {
-                if (menu.style.display === 'block' && !menu.contains(e.target) && e.target !== confidenceInput) {
-                    hideMenu();
-                }
-            });
-        } else {
-            // Desktop: simply refocus the guess input after a selection
-            confidenceInput.addEventListener('change', () => guessInput.focus());
-        }
+        confidenceInput.addEventListener('pointerdown', handlePointerDown);
+        confidenceInput.addEventListener('change', () => {
+            // Refocus after choosing a confidence so typing can continue
+            setTimeout(() => guessInput.focus({ preventScroll: true }), 0);
+        });
     }
 
     // Help button

--- a/script.js
+++ b/script.js
@@ -2552,13 +2552,20 @@ function setupEventListeners() {
         }
     });
 
-    // Refocus guess input after selecting confidence so the mobile keyboard stays open
-    if (confidenceInput) {
-        confidenceInput.addEventListener('change', () => {
-            if (guessInput) {
-                // Delay refocus until after the select menu closes
-                setTimeout(() => guessInput.focus(), 100);
+    // Keep guess input focused when picking a confidence value so the keyboard stays open
+    if (confidenceInput && guessInput) {
+        const openPickerWithoutBlur = (e) => {
+            if (document.activeElement === guessInput && confidenceInput.showPicker) {
+                e.preventDefault();
+                confidenceInput.showPicker();
             }
+        };
+
+        confidenceInput.addEventListener('mousedown', openPickerWithoutBlur);
+        confidenceInput.addEventListener('touchstart', openPickerWithoutBlur);
+        confidenceInput.addEventListener('change', () => {
+            // Ensure the guess input regains focus after a selection is made
+            guessInput.focus();
         });
     }
 

--- a/script.js
+++ b/script.js
@@ -2556,7 +2556,8 @@ function setupEventListeners() {
     if (confidenceInput) {
         confidenceInput.addEventListener('change', () => {
             if (guessInput) {
-                guessInput.focus();
+                // Delay refocus until after the select menu closes
+                setTimeout(() => guessInput.focus(), 100);
             }
         });
     }

--- a/script.js
+++ b/script.js
@@ -2554,19 +2554,55 @@ function setupEventListeners() {
 
     // Keep guess input focused when picking a confidence value so the keyboard stays open
     if (confidenceInput && guessInput) {
-        const openPickerWithoutBlur = (e) => {
-            if (document.activeElement === guessInput && confidenceInput.showPicker) {
-                e.preventDefault();
-                confidenceInput.showPicker();
-            }
-        };
+        const useCustomMenu = () => isSmallDevice() && 'ontouchstart' in window;
 
-        confidenceInput.addEventListener('mousedown', openPickerWithoutBlur);
-        confidenceInput.addEventListener('touchstart', openPickerWithoutBlur);
-        confidenceInput.addEventListener('change', () => {
-            // Ensure the guess input regains focus after a selection is made
-            guessInput.focus();
-        });
+        if (useCustomMenu()) {
+            // Build a lightweight menu so selecting confidence doesn't blur the guess input
+            const menu = document.createElement('div');
+            menu.id = 'confidence-menu';
+            menu.style.display = 'none';
+
+            const hideMenu = () => {
+                menu.style.display = 'none';
+            };
+
+            Array.from(confidenceInput.options).forEach(opt => {
+                const btn = document.createElement('button');
+                btn.type = 'button';
+                btn.textContent = opt.textContent;
+                btn.addEventListener('click', () => {
+                    confidenceInput.value = opt.value;
+                    confidenceInput.dispatchEvent(new Event('change', { bubbles: true }));
+                    hideMenu();
+                    guessInput.focus();
+                });
+                menu.appendChild(btn);
+            });
+
+            document.body.appendChild(menu);
+
+            const showMenu = (e) => {
+                e.preventDefault();
+                const rect = confidenceInput.getBoundingClientRect();
+                menu.style.left = `${rect.left + window.scrollX}px`;
+                menu.style.top = `${rect.bottom + window.scrollY}px`;
+                menu.style.display = 'block';
+                // Ensure guess input keeps focus so keyboard stays visible
+                guessInput.focus();
+            };
+
+            confidenceInput.addEventListener('mousedown', showMenu);
+            confidenceInput.addEventListener('touchstart', showMenu);
+
+            document.addEventListener('click', (e) => {
+                if (menu.style.display === 'block' && !menu.contains(e.target) && e.target !== confidenceInput) {
+                    hideMenu();
+                }
+            });
+        } else {
+            // Desktop: simply refocus the guess input after a selection
+            confidenceInput.addEventListener('change', () => guessInput.focus());
+        }
     }
 
     // Help button

--- a/script.js
+++ b/script.js
@@ -2542,7 +2542,7 @@ function setupEventListeners() {
     guessInput.addEventListener('input', (e) => {
         const input = e.target;
         const value = input.value.replace(/[^\d]/g, ''); // Keep only digits
-        
+
         if (value === '') {
             input.value = '';
         } else {
@@ -2551,7 +2551,16 @@ function setupEventListeners() {
             input.value = formattedValue;
         }
     });
-    
+
+    // Refocus guess input after selecting confidence so the mobile keyboard stays open
+    if (confidenceInput) {
+        confidenceInput.addEventListener('change', () => {
+            if (guessInput) {
+                guessInput.focus();
+            }
+        });
+    }
+
     // Help button
     helpBtn.addEventListener('click', showHelp);
     

--- a/styles.css
+++ b/styles.css
@@ -1071,3 +1071,26 @@ button#stats-btn {
 .shake {
     animation: shake 0.5s ease-in-out;
 }
+
+/* Custom confidence menu used on mobile to keep keyboard open */
+#confidence-menu {
+    position: absolute;
+    background: #fff;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+    z-index: 1000;
+}
+
+#confidence-menu button {
+    display: block;
+    width: 100%;
+    padding: 8px 12px;
+    background: none;
+    border: none;
+    text-align: left;
+}
+
+#confidence-menu button:hover {
+    background: #f0f0f0;
+}

--- a/styles.css
+++ b/styles.css
@@ -1072,25 +1072,3 @@ button#stats-btn {
     animation: shake 0.5s ease-in-out;
 }
 
-/* Custom confidence menu used on mobile to keep keyboard open */
-#confidence-menu {
-    position: absolute;
-    background: #fff;
-    border: 1px solid #ccc;
-    border-radius: 4px;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
-    z-index: 1000;
-}
-
-#confidence-menu button {
-    display: block;
-    width: 100%;
-    padding: 8px 12px;
-    background: none;
-    border: none;
-    text-align: left;
-}
-
-#confidence-menu button:hover {
-    background: #f0f0f0;
-}


### PR DESCRIPTION
## Summary
- Re-focus guess input after selecting a confidence value so the mobile keyboard remains visible.

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68baad3b8dec8329be78770a512f6d5e