### PR TITLE
fix: close keyboard before confidence picker

### DIFF
--- a/script.js
+++ b/script.js
@@ -2563,12 +2563,15 @@ function setupEventListeners() {
             const heightDifference = Math.abs(currentHeight - initialViewportHeight);
             if (heightDifference < 50) {
                 pendingOpen = false;
-                confidenceInput.focus({ preventScroll: true });
-                if (typeof confidenceInput.showPicker === 'function') {
-                    confidenceInput.showPicker();
-                } else {
-                    confidenceInput.click();
-                }
+                // Allow viewport to settle after keyboard closes before opening picker
+                setTimeout(() => {
+                    confidenceInput.focus({ preventScroll: true });
+                    if (typeof confidenceInput.showPicker === 'function') {
+                        confidenceInput.showPicker();
+                    } else {
+                        confidenceInput.click();
+                    }
+                }, 100);
             } else {
                 setTimeout(checkViewportAndOpen, 50);
             }

--- a/script.js
+++ b/script.js
@@ -2554,21 +2554,43 @@ function setupEventListeners() {
 
     // Ensure keyboard closes before opening confidence menu on mobile
     if (confidenceInput && guessInput) {
+        let initialViewportHeight = window.innerHeight;
+        let pendingOpen = false;
+
+        const checkViewportAndOpen = () => {
+            if (!pendingOpen) return;
+            const currentHeight = window.innerHeight;
+            const heightDifference = Math.abs(currentHeight - initialViewportHeight);
+            if (heightDifference < 50) {
+                pendingOpen = false;
+                confidenceInput.focus({ preventScroll: true });
+                if (typeof confidenceInput.showPicker === 'function') {
+                    confidenceInput.showPicker();
+                } else {
+                    confidenceInput.click();
+                }
+            } else {
+                setTimeout(checkViewportAndOpen, 50);
+            }
+        };
+
         const openConfidencePicker = (e) => {
             if (document.activeElement === guessInput) {
                 e.preventDefault();
                 guessInput.blur();
-                setTimeout(() => {
-                    confidenceInput.focus({ preventScroll: true });
-                    if (typeof confidenceInput.showPicker === 'function') {
-                        confidenceInput.showPicker();
-                    } else {
-                        confidenceInput.click();
-                    }
-                }, 100);
+                pendingOpen = true;
+                checkViewportAndOpen();
             }
         };
+
+        window.addEventListener('resize', () => {
+            if (!pendingOpen) {
+                initialViewportHeight = window.innerHeight;
+            }
+        });
+
         confidenceInput.addEventListener('touchend', openConfidencePicker, { passive: false });
+        confidenceInput.addEventListener('click', openConfidencePicker);
     }
 
     // Help button

--- a/script.js
+++ b/script.js
@@ -2554,43 +2554,28 @@ function setupEventListeners() {
 
     // Ensure keyboard closes before opening confidence menu on mobile
     if (confidenceInput && guessInput) {
-        let initialViewportHeight = window.innerHeight;
-        let pendingOpen = false;
+        const openConfidencePicker = (e) => {
+            if (document.activeElement !== guessInput) return;
 
-        const checkViewportAndOpen = () => {
-            if (!pendingOpen) return;
-            const currentHeight = window.innerHeight;
-            const heightDifference = Math.abs(currentHeight - initialViewportHeight);
-            if (heightDifference < 50) {
-                pendingOpen = false;
-                // Allow viewport to settle after keyboard closes before opening picker
-                setTimeout(() => {
+            e.preventDefault();
+            const keyboardHeight = window.innerHeight;
+            guessInput.blur();
+
+            const waitForKeyboardClose = () => {
+                if (window.innerHeight >= keyboardHeight + 50) {
                     confidenceInput.focus({ preventScroll: true });
                     if (typeof confidenceInput.showPicker === 'function') {
                         confidenceInput.showPicker();
                     } else {
                         confidenceInput.click();
                     }
-                }, 100);
-            } else {
-                setTimeout(checkViewportAndOpen, 50);
-            }
-        };
+                } else {
+                    requestAnimationFrame(waitForKeyboardClose);
+                }
+            };
 
-        const openConfidencePicker = (e) => {
-            if (document.activeElement === guessInput) {
-                e.preventDefault();
-                guessInput.blur();
-                pendingOpen = true;
-                checkViewportAndOpen();
-            }
+            requestAnimationFrame(waitForKeyboardClose);
         };
-
-        window.addEventListener('resize', () => {
-            if (!pendingOpen) {
-                initialViewportHeight = window.innerHeight;
-            }
-        });
 
         confidenceInput.addEventListener('touchend', openConfidencePicker, { passive: false });
         confidenceInput.addEventListener('click', openConfidencePicker);

--- a/script.js
+++ b/script.js
@@ -2557,15 +2557,20 @@ function setupEventListeners() {
         const openConfidencePicker = (e) => {
             if (document.activeElement === guessInput) {
                 e.preventDefault();
-                guessInput.blur();
-                setTimeout(() => {
+                const openPicker = () => {
                     confidenceInput.focus({ preventScroll: true });
                     if (typeof confidenceInput.showPicker === 'function') {
                         confidenceInput.showPicker();
                     } else {
                         confidenceInput.click();
                     }
-                }, 100);
+                };
+                guessInput.addEventListener(
+                    'blur',
+                    () => setTimeout(openPicker, 0),
+                    { once: true }
+                );
+                guessInput.blur();
             }
         };
         confidenceInput.addEventListener('touchstart', openConfidencePicker, { passive: false });

--- a/script.js
+++ b/script.js
@@ -2542,7 +2542,7 @@ function setupEventListeners() {
     guessInput.addEventListener('input', (e) => {
         const input = e.target;
         const value = input.value.replace(/[^\d]/g, ''); // Keep only digits
-        
+
         if (value === '') {
             input.value = '';
         } else {
@@ -2551,7 +2551,26 @@ function setupEventListeners() {
             input.value = formattedValue;
         }
     });
-    
+
+    // Ensure keyboard closes before opening confidence menu on mobile
+    if (confidenceInput && guessInput) {
+        const openConfidencePicker = (e) => {
+            if (document.activeElement === guessInput) {
+                e.preventDefault();
+                guessInput.blur();
+                setTimeout(() => {
+                    confidenceInput.focus({ preventScroll: true });
+                    if (typeof confidenceInput.showPicker === 'function') {
+                        confidenceInput.showPicker();
+                    } else {
+                        confidenceInput.click();
+                    }
+                }, 100);
+            }
+        };
+        confidenceInput.addEventListener('touchstart', openConfidencePicker, { passive: false });
+    }
+
     // Help button
     helpBtn.addEventListener('click', showHelp);
     

--- a/script.js
+++ b/script.js
@@ -2554,15 +2554,19 @@ function setupEventListeners() {
 
     // Ensure keyboard closes before opening confidence menu on mobile
     if (confidenceInput && guessInput) {
+        const getViewportHeight = () => window.visualViewport ? window.visualViewport.height : window.innerHeight;
+
         const openConfidencePicker = (e) => {
             if (document.activeElement !== guessInput) return;
 
             e.preventDefault();
-            const keyboardHeight = window.innerHeight;
+            const startHeight = getViewportHeight();
             guessInput.blur();
 
+            let checks = 0;
             const waitForKeyboardClose = () => {
-                if (window.innerHeight >= keyboardHeight + 50) {
+                const currentHeight = getViewportHeight();
+                if (currentHeight - startHeight > 50 || checks > 10) {
                     confidenceInput.focus({ preventScroll: true });
                     if (typeof confidenceInput.showPicker === 'function') {
                         confidenceInput.showPicker();
@@ -2570,11 +2574,12 @@ function setupEventListeners() {
                         confidenceInput.click();
                     }
                 } else {
-                    requestAnimationFrame(waitForKeyboardClose);
+                    checks++;
+                    setTimeout(waitForKeyboardClose, 50);
                 }
             };
 
-            requestAnimationFrame(waitForKeyboardClose);
+            setTimeout(waitForKeyboardClose, 50);
         };
 
         confidenceInput.addEventListener('touchend', openConfidencePicker, { passive: false });

--- a/script.js
+++ b/script.js
@@ -2557,23 +2557,18 @@ function setupEventListeners() {
         const openConfidencePicker = (e) => {
             if (document.activeElement === guessInput) {
                 e.preventDefault();
-                const openPicker = () => {
+                guessInput.blur();
+                setTimeout(() => {
                     confidenceInput.focus({ preventScroll: true });
                     if (typeof confidenceInput.showPicker === 'function') {
                         confidenceInput.showPicker();
                     } else {
                         confidenceInput.click();
                     }
-                };
-                guessInput.addEventListener(
-                    'blur',
-                    () => setTimeout(openPicker, 0),
-                    { once: true }
-                );
-                guessInput.blur();
+                }, 100);
             }
         };
-        confidenceInput.addEventListener('touchstart', openConfidencePicker, { passive: false });
+        confidenceInput.addEventListener('touchend', openConfidencePicker, { passive: false });
     }
 
     // Help button


### PR DESCRIPTION
## Summary
- close guess input before opening confidence select on touch devices

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68bab35df36c8329b692f82a62f70fc3