### PR TITLE
fix: ensure calibration select opens after keyboard closes

### DIFF
--- a/script.js
+++ b/script.js
@@ -2588,6 +2588,24 @@ function setupEventListeners() {
         }
     });
 
+    // On mobile, ensure confidence select opens after keyboard closes
+    if (confidenceInput) {
+        confidenceInput.addEventListener('touchstart', (e) => {
+            // Prevent immediate native handling so we can close the keyboard first
+            e.preventDefault();
+            // Close the numeric keyboard from the guess input
+            guessInput.blur();
+            // Wait for viewport to adjust, then show the picker
+            setTimeout(() => {
+                if (typeof confidenceInput.showPicker === 'function') {
+                    confidenceInput.showPicker();
+                } else {
+                    confidenceInput.focus();
+                }
+            }, 100);
+        });
+    }
+
     // Help button
     helpBtn.addEventListener('click', showHelp);
     


### PR DESCRIPTION
## Summary
- close the guess input keyboard and wait before opening the calibration select on mobile

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc56ddc0d8832988445b89cac63d70