### PR TITLE
Fix mobile calibration select misplacement

### DIFF
--- a/script.js
+++ b/script.js
@@ -2645,10 +2645,18 @@ function setupEventListeners() {
                 guessInput.blur();
                 setTimeout(() => {
                     confidenceInput.scrollIntoView({ block: 'center' });
-                    if (typeof confidenceInput.showPicker === 'function') {
-                        confidenceInput.showPicker();
-                    } else {
+                    // Some browsers don't support showPicker; fall back to
+                    // programmatically clicking the select to open it.
+                    try {
+                        if (typeof confidenceInput.showPicker === 'function') {
+                            confidenceInput.showPicker();
+                        } else {
+                            confidenceInput.focus();
+                            confidenceInput.click();
+                        }
+                    } catch (_) {
                         confidenceInput.focus();
+                        confidenceInput.click();
                     }
                 }, 100);
             }

--- a/script.js
+++ b/script.js
@@ -2631,6 +2631,31 @@ function setupEventListeners() {
             updateConfidenceInputVisibility();
         });
     }
+
+    // When the guess input is focused on mobile devices, opening the
+    // confidence selector immediately can position its dropdown based on the
+    // pre-keyboard layout. Blur the guess input first and show the picker after
+    // a short delay so the dropdown is positioned correctly once the keyboard
+    // is hidden.
+    if (confidenceInput && guessInput) {
+        const handleConfidenceOpen = (e) => {
+            if (!isSmallDevice()) return;
+            if (document.activeElement === guessInput) {
+                e.preventDefault();
+                guessInput.blur();
+                setTimeout(() => {
+                    confidenceInput.scrollIntoView({ block: 'center' });
+                    if (typeof confidenceInput.showPicker === 'function') {
+                        confidenceInput.showPicker();
+                    } else {
+                        confidenceInput.focus();
+                    }
+                }, 100);
+            }
+        };
+        confidenceInput.addEventListener('mousedown', handleConfidenceOpen);
+        confidenceInput.addEventListener('touchstart', handleConfidenceOpen, { passive: false });
+    }
     
     // Source button opens explanation modal
     if (sourceBtn && sourceModal) {


### PR DESCRIPTION
## Summary
- Ensure confidence select is shown only after keyboard closes on mobile
- Prevent mispositioned dropdown by blurring guess input and delaying picker

## Testing
- `npm test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bc56ddc0d8832988445b89cac63d70