### PR TITLE
Ensure calibration select opens correctly on mobile

### DIFF
--- a/script.js
+++ b/script.js
@@ -775,6 +775,21 @@ const calibrationChart = document.getElementById('calibration-chart');
 const calibrationTooltip = document.getElementById('calibration-tooltip');
 const calibrationNote = document.querySelector('.calibration-note');
 
+// Ensure mobile select opens after keyboard closes to avoid mispositioned dropdown
+if (confidenceInput && guessInput) {
+    confidenceInput.addEventListener('touchstart', (e) => {
+        if (document.activeElement === guessInput) {
+            e.preventDefault();
+            // Close the mobile keyboard and wait before opening the select
+            guessInput.blur();
+            setTimeout(() => {
+                confidenceInput.focus();
+                confidenceInput.click();
+            }, 100);
+        }
+    });
+}
+
 // Initialize game
 function initGame() {
     // Initialize Supabase first


### PR DESCRIPTION
## Summary
- Delay opening the calibration confidence select until after the guess input's keyboard closes to avoid misaligned dropdowns on mobile.

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc56ddc0d8832988445b89cac63d70