### PR TITLE
Fix mobile calibration select misplacement

### DIFF
--- a/script.js
+++ b/script.js
@@ -2631,6 +2631,31 @@ function setupEventListeners() {
             updateConfidenceInputVisibility();
         });
     }
+
+    // When the guess input is focused on mobile devices, opening the
+    // confidence selector immediately can position its dropdown based on the
+    // pre-keyboard layout. Blur the guess input first and show the picker after
+    // a short delay so the dropdown is positioned correctly once the keyboard
+    // is hidden.
+    if (confidenceInput && guessInput) {
+        const handleConfidenceOpen = (e) => {
+            if (!isSmallDevice()) return;
+            if (document.activeElement === guessInput) {
+                e.preventDefault();
+                guessInput.blur();
+                setTimeout(() => {
+                    confidenceInput.scrollIntoView({ block: 'center' });
+                    // Focus then trigger a synthetic click to open the
+                    // native picker. This avoids relying on showPicker(),
+                    // which isn't supported on all browsers.
+                    confidenceInput.focus();
+                    confidenceInput.click();
+                }, 100);
+            }
+        };
+        confidenceInput.addEventListener('mousedown', handleConfidenceOpen);
+        confidenceInput.addEventListener('touchstart', handleConfidenceOpen, { passive: false });
+    }
     
     // Source button opens explanation modal
     if (sourceBtn && sourceModal) {


### PR DESCRIPTION
## Summary
- Ensure calibration dropdown opens after keyboard hides on small devices
- Replace unsupported showPicker usage with focus+click to trigger native picker

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc56ddc0d8832988445b89cac63d70