### PR TITLE
feat: custom mobile confidence dropdown

### DIFF
--- a/index.html
+++ b/index.html
@@ -112,18 +112,33 @@
                         inputmode="numeric"
                         pattern="[0-9,]*"
                     >
-                    <select id="confidence-input">
-                        <option value="10">10%</option>
-                        <option value="20">20%</option>
-                        <option value="30">30%</option>
-                        <option value="40">40%</option>
-                        <option value="50" selected>50%</option>
-                        <option value="60">60%</option>
-                        <option value="70">70%</option>
-                        <option value="80">80%</option>
-                        <option value="90">90%</option>
-                        <option value="100">100%</option>
-                    </select>
+                    <div class="confidence-wrapper">
+                        <select id="confidence-input">
+                            <option value="10">10%</option>
+                            <option value="20">20%</option>
+                            <option value="30">30%</option>
+                            <option value="40">40%</option>
+                            <option value="50" selected>50%</option>
+                            <option value="60">60%</option>
+                            <option value="70">70%</option>
+                            <option value="80">80%</option>
+                            <option value="90">90%</option>
+                            <option value="100">100%</option>
+                        </select>
+                        <button id="confidence-button" type="button" aria-haspopup="listbox" aria-expanded="false">50%</button>
+                        <div id="confidence-menu" class="confidence-menu" role="listbox">
+                            <button type="button" data-value="10" role="option">10%</button>
+                            <button type="button" data-value="20" role="option">20%</button>
+                            <button type="button" data-value="30" role="option">30%</button>
+                            <button type="button" data-value="40" role="option">40%</button>
+                            <button type="button" data-value="50" role="option">50%</button>
+                            <button type="button" data-value="60" role="option">60%</button>
+                            <button type="button" data-value="70" role="option">70%</button>
+                            <button type="button" data-value="80" role="option">80%</button>
+                            <button type="button" data-value="90" role="option">90%</button>
+                            <button type="button" data-value="100" role="option">100%</button>
+                        </div>
+                    </div>
                 </div>
                 <button id="submit-btn" class="submit-btn">Submit</button>
             </div>

--- a/script.js
+++ b/script.js
@@ -747,6 +747,8 @@ const correctAnswer = document.getElementById('correct-answer');
 const guessesContainer = document.getElementById('guesses-container');
 const guessInput = document.getElementById('guess-input');
 const confidenceInput = document.getElementById('confidence-input');
+const confidenceButton = document.getElementById('confidence-button');
+const confidenceMenu = document.getElementById('confidence-menu');
 const submitBtn = document.getElementById('submit-btn');
 const sendIcon = `\
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
@@ -1803,13 +1805,26 @@ function updateConfidenceInputVisibility() {
     const firstOnlyActive = firstGuessCheckbox && firstGuessCheckbox.checked;
     const showConfidence = calibrationEnabled && (!firstOnlyActive || currentGuess === 0);
 
-    if (confidenceInput) {
+    if (confidenceInput && confidenceButton) {
         const prevValue = confidenceInput.value;
-        confidenceInput.style.display = showConfidence ? 'block' : 'none';
         if (showConfidence) {
-            confidenceInput.value = prevValue || '50';
+            const val = prevValue || '50';
+            confidenceInput.value = val;
+            confidenceButton.textContent = val + '%';
         } else {
             confidenceInput.value = '';
+            confidenceMenu && confidenceMenu.classList.remove('open');
+            confidenceButton.setAttribute('aria-expanded', 'false');
+        }
+
+        if (isSmallDevice()) {
+            confidenceInput.style.display = 'none';
+            confidenceButton.style.display = showConfidence ? 'block' : 'none';
+        } else {
+            confidenceInput.style.display = showConfidence ? 'block' : 'none';
+            confidenceButton.style.display = 'none';
+            confidenceMenu && confidenceMenu.classList.remove('open');
+            confidenceButton.setAttribute('aria-expanded', 'false');
         }
     }
     applySubmitButtonState();
@@ -2641,29 +2656,46 @@ function setupEventListeners() {
         });
     }
 
-    // When the guess input is focused on mobile devices, opening the
-    // confidence selector immediately can position its dropdown based on the
-    // pre-keyboard layout. Blur the guess input first and show the picker after
-    // a short delay so the dropdown is positioned correctly once the keyboard
-    // is hidden.
-    if (confidenceInput && guessInput) {
+    // Mobile-only custom confidence dropdown
+    if (confidenceButton && confidenceMenu && guessInput) {
+        const openMenu = () => {
+            const isOpen = confidenceMenu.classList.toggle('open');
+            confidenceButton.setAttribute('aria-expanded', isOpen);
+        };
+
         const handleConfidenceOpen = (e) => {
             if (!isSmallDevice()) return;
             if (document.activeElement === guessInput) {
                 e.preventDefault();
                 guessInput.blur();
                 setTimeout(() => {
-                    confidenceInput.scrollIntoView({ block: 'center' });
-                    // Focus then trigger a synthetic click to open the
-                    // native picker. This avoids relying on showPicker(),
-                    // which isn't supported on all browsers.
-                    confidenceInput.focus();
-                    confidenceInput.click();
+                    confidenceButton.scrollIntoView({ block: 'center' });
+                    openMenu();
                 }, 100);
+            } else {
+                openMenu();
             }
         };
-        confidenceInput.addEventListener('mousedown', handleConfidenceOpen);
-        confidenceInput.addEventListener('touchstart', handleConfidenceOpen, { passive: false });
+
+        confidenceButton.addEventListener('mousedown', handleConfidenceOpen);
+        confidenceButton.addEventListener('touchstart', handleConfidenceOpen, { passive: false });
+
+        confidenceMenu.addEventListener('click', (e) => {
+            if (e.target.matches('button[data-value]')) {
+                const value = e.target.getAttribute('data-value');
+                confidenceInput.value = value;
+                confidenceButton.textContent = value + '%';
+                confidenceMenu.classList.remove('open');
+                confidenceButton.setAttribute('aria-expanded', 'false');
+            }
+        });
+
+        document.addEventListener('click', (e) => {
+            if (confidenceMenu.classList.contains('open') && !confidenceMenu.contains(e.target) && e.target !== confidenceButton) {
+                confidenceMenu.classList.remove('open');
+                confidenceButton.setAttribute('aria-expanded', 'false');
+            }
+        });
     }
     
     // Source button opens explanation modal

--- a/styles.css
+++ b/styles.css
@@ -671,6 +671,61 @@ button#stats-btn {
     display: none;
 }
 
+.confidence-wrapper {
+    position: relative;
+}
+
+#confidence-button {
+    margin: 0 10px 0 0;
+    height: 100%;
+    width: 71px;
+    padding: 18.5px 0;
+    background: none;
+    padding-right: 0;
+    border: none;
+    border-left: 2px solid #eaecf0;
+    color: #333;
+    font-size: 1rem;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+    text-align: right;
+    padding-inline-start: 0;
+    display: none;
+    cursor: pointer;
+}
+
+.confidence-menu {
+    position: absolute;
+    bottom: calc(100% + 4px);
+    left: 0;
+    width: 100%;
+    background: #fff;
+    border: 1px solid #ccc;
+    border-radius: 12px;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+    display: none;
+    flex-direction: column;
+    overflow: hidden;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+    z-index: 1000;
+}
+
+.confidence-menu.open {
+    display: flex;
+}
+
+.confidence-menu button {
+    padding: 12px 0;
+    background: none;
+    border: none;
+    color: #007aff;
+    font-size: 1rem;
+    cursor: pointer;
+}
+
+.confidence-menu button:not(:last-child) {
+    border-bottom: 1px solid #ccc;
+}
+
 .submit-btn {
     width: 110px;
     height: 54px;


### PR DESCRIPTION
## Summary
- replace calibration select with custom mobile dropdown
- style dropdown like iOS and use system fonts
- manage dropdown interactions via JavaScript

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68bd4c0f02bc832989d8535aedfd986d