### PR TITLE
Scroll to top on game end and add calibration banner

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,6 +33,12 @@
             </div>
         </header>
     <div class="game-container">
+        <!-- Calibration Banner -->
+        <div class="alert-banner" id="calibration-banner" style="display: none;">
+            <label>
+                <input type="checkbox" id="prob-calibration-checkbox-banner" class="prob-calibration-checkbox"> Enable probability calibration mode
+            </label>
+        </div>
         <!-- Question Display -->
         <div class="question-container">
             <div class="question-box">

--- a/script.js
+++ b/script.js
@@ -785,6 +785,7 @@ const firstGuessCheckbox = document.getElementById('first-guess-checkbox');
 const calibrationChart = document.getElementById('calibration-chart');
 const calibrationTooltip = document.getElementById('calibration-tooltip');
 const calibrationNote = document.querySelector('.calibration-note');
+const calibrationBanner = document.getElementById('calibration-banner');
 
 // Initialize game
 function initGame() {
@@ -1482,8 +1483,9 @@ function endGame() {
     } else {
         newGameBtnInline.textContent = 'Play more';
         newGameBtnInline.onclick = startNewGame;
-    }    
+    }
     updateStreakDisplay(); // Update streak display when game ends
+    window.scrollTo(0, 0);
 }
 
 // Start a new game
@@ -1779,6 +1781,11 @@ function loadCompletedQuestions() {
     }
 }
 
+function updateCalibrationBanner() {
+    if (!calibrationBanner) return;
+    calibrationBanner.style.display = calibrationEnabled ? 'none' : 'block';
+}
+
 function loadCalibrationSetting() {
     calibrationEnabled = localStorage.getItem('fermiCalibrationEnabled') === 'true';
     calibrationCheckboxes.forEach(cb => {
@@ -1790,6 +1797,7 @@ function loadCalibrationSetting() {
     }
     updateConfidenceInputVisibility();
     updateCalibrationChart();
+    updateCalibrationBanner();
 }
 
 function setCalibrationEnabled(enabled) {
@@ -1799,6 +1807,7 @@ function setCalibrationEnabled(enabled) {
         cb.checked = enabled;
     });
     updateConfidenceInputVisibility();
+    updateCalibrationBanner();
 }
 
 function updateConfidenceInputVisibility() {
@@ -2128,6 +2137,7 @@ function endGameDisplay() {
         newGameBtnInline.textContent = 'Play more';
         newGameBtnInline.onclick = startNewGame;
     }
+    window.scrollTo(0, 0);
 }
 
 // Show questions history modal

--- a/styles.css
+++ b/styles.css
@@ -17,7 +17,23 @@ body {
     margin: 0 auto;
     background-color: #ffffff;
     border-radius: 18px;
-    padding: 20px;    
+    padding: 20px;
+}
+
+/* Alert banner for calibration mode */
+.alert-banner {
+    background-color: #fff3cd;
+    border: 2px solid #ffeeba;
+    color: #856404;
+    padding: 12px;
+    border-radius: 16px;
+    margin-bottom: 20px;
+    font-size: 0.75rem;
+    text-align: center;
+}
+
+.alert-banner label {
+    cursor: pointer;
 }
 
 /* Header */


### PR DESCRIPTION
## Summary
- Scroll to the top when a game ends so results are immediately visible
- Add an alert banner with a probability calibration toggle
- Wire banner toggle into existing calibration mode logic

## Testing
- `npm test` *(fails: could not read package.json)*
- `npm run lint` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bdba072bd8832986da4ef4868b00ce