### PR TITLE
Show comment timestamps and update styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,13 +65,13 @@
         <!-- Comments Section -->
         <div class="comments-section" id="comments-section">
             <div class="comments-header">
-                <button class="icon-button" id="comments-back-btn">&larr;</button>
+                <button class="icon-button" id="comments-back-btn">&lt;</button>
                 <h2>Comments</h2>
             </div>
             <div class="comments-list" id="comments-list"></div>
             <div class="comments-input">
                 <textarea id="comment-input" placeholder="Add a comment..."></textarea>
-                <button id="comment-submit-btn" class="icon-button">Post</button>
+                <button id="comment-submit-btn" class="submit-btn">Post</button>
             </div>
         </div>
 

--- a/script.js
+++ b/script.js
@@ -279,9 +279,9 @@ async function fetchComments(questionDate) {
     try {
         const { data, error } = await supabase
             .from('comments')
-            .select('id, content, guess_count, created_at')
+            .select('id, content, guess_count, won, created_at')
             .eq('question_date', questionDate)
-            .order('created_at', { ascending: true });
+            .order('created_at', { ascending: false });
         if (error || !data) return [];
         return data;
     } catch (e) {
@@ -294,6 +294,8 @@ async function fetchComments(questionDate) {
 async function addComment(questionDate, content) {
     if (!supabase || !currentUserId) return;
     const guessCount = getGuessCountForComment();
+    const completed = completedQuestions[currentQuestion.date];
+    const won = completed ? completed.won : gameWon;
     try {
         await supabase
             .from('comments')
@@ -302,6 +304,7 @@ async function addComment(questionDate, content) {
                 question_date: questionDate,
                 content,
                 guess_count: guessCount,
+                won,
                 created_at: new Date().toISOString()
             });
     } catch (e) {
@@ -319,8 +322,32 @@ function getGuessCountForComment() {
     return null;
 }
 
+function formatTimeAgo(dateString) {
+    const now = new Date();
+    const date = new Date(dateString);
+    const diffMs = now - date;
+    const diffMinutes = Math.floor(diffMs / 60000);
+    if (diffMinutes < 1) return 'just now';
+    if (diffMinutes < 60) {
+        return diffMinutes === 1 ? '1 minute ago' : `${diffMinutes} minutes ago`;
+    }
+    const diffHours = Math.floor(diffMinutes / 60);
+    if (diffHours < 24) {
+        return diffHours === 1 ? '1 hour ago' : `${diffHours} hours ago`;
+    }
+    const diffDays = Math.floor(diffHours / 24);
+    return diffDays === 1 ? '1 day ago' : `${diffDays} days ago`;
+}
+
 // Load comments and update display
 async function loadComments() {
+    if (!commentsList) return;
+    // Clear immediately to avoid showing comments from previous questions
+    commentsList.innerHTML = '';
+    const loading = document.createElement('p');
+    loading.textContent = 'Loading comments...';
+    commentsList.appendChild(loading);
+
     if (!currentQuestion) return;
     const comments = await fetchComments(currentQuestion.date);
     renderComments(comments);
@@ -345,13 +372,18 @@ function renderComments(comments) {
         textEl.textContent = c.content;
         div.appendChild(textEl);
 
-        if (c.guess_count != null) {
-            const metaEl = document.createElement('div');
-            metaEl.className = 'comment-meta';
-            const tries = c.guess_count === 1 ? '1 try' : `${c.guess_count} tries`;
-            metaEl.textContent = tries;
-            div.appendChild(metaEl);
+        const metaEl = document.createElement('div');
+        metaEl.className = 'comment-meta';
+        const timeAgo = formatTimeAgo(c.created_at);
+        if (c.won === false) {
+            metaEl.textContent = `Lost · ${timeAgo}`;
+        } else if (c.guess_count != null) {
+            const tries = `${c.guess_count}/6 tries`;
+            metaEl.textContent = `${tries} · ${timeAgo}`;
+        } else {
+            metaEl.textContent = timeAgo;
         }
+        div.appendChild(metaEl);
 
         commentsList.appendChild(div);
     });
@@ -977,6 +1009,10 @@ function updateQuestionDisplay(question) {
     } else {
         questionImageContainer.style.display = 'none';
     }
+
+    // Clear any comments from a previous question immediately
+    if (commentsList) commentsList.innerHTML = '';
+    if (commentCountEl) commentCountEl.textContent = '0';
 
     updateCommentCount();
     subscribeToComments(question.date);

--- a/styles.css
+++ b/styles.css
@@ -168,6 +168,8 @@ button#stats-btn {
     align-items: center;
     justify-content: center;
     gap: 12px;
+    font-family: 'Press Start 2P', monospace;
+    font-size: 0.8rem;
 }
 
 .streak-emoji { 
@@ -1015,6 +1017,9 @@ button#stats-btn {
     .icon-button {
         background: #f4f8fa;
     }
+    .comments-header .icon-button {
+        background: transparent;
+    }
     .game-header {
         padding: 18px 0;
     }
@@ -1112,6 +1117,7 @@ button#stats-btn {
         padding: 25.75px 12px 16px 0;
         font-size: 0.78rem;
         height: 63px;
+        font-family: 'Press Start 2P', monospace;
     }
     .source-btn {
         font-size: 0.78rem;
@@ -1163,6 +1169,7 @@ button#stats-btn {
     background: #fff;
     z-index: 1000;
     flex-direction: column;
+    border-radius: 18px;
 }
 
 .comments-section.open {
@@ -1173,21 +1180,25 @@ button#stats-btn {
     display: flex;
     align-items: center;
     gap: 12px;
-    padding: 12px;
+    padding: 16px 20px;
     border-bottom: 1px solid #e9ecef;
+}
+
+.comments-header h2 {
+    font-size: 0.9375rem;
 }
 
 .comments-list {
     flex: 1;
     overflow-y: auto;
-    padding: 12px;
+    padding: 20px;
 }
 
 .comment {
     margin-bottom: 12px;
     padding-bottom: 12px;
     border-bottom: 1px solid #e9ecef;
-    font-size: 0.9rem;
+    font-size: 0.8rem;
 }
 
 .comment-text {
@@ -1196,21 +1207,31 @@ button#stats-btn {
 
 .comment-meta {
     display: block;
-    margin-top: 4px;
+    margin-top: 6px;
     color: #666;
-    font-size: 0.75rem;
+    font-size: 0.7rem;
 }
 
 .comments-input {
-    padding: 12px;
+    padding: 20px;
     border-top: 1px solid #e9ecef;
     display: flex;
-    gap: 8px;
+    gap: 10px;
+    align-items: center;
 }
 
 .comments-input textarea {
     flex: 1;
     resize: none;
+    min-height: 54px;
+    background: none;
+    border: 2px solid #eaecf0;
+    border-radius: 15px;
+    font-family: 'Press Start 2P', monospace;
+    font-size: 0.8rem;
+    padding: 18.5px 15px;
+    outline: none;
+    line-height: 1.4;
 }
 
 @media (max-width: 768px) {
@@ -1218,8 +1239,7 @@ button#stats-btn {
         position: fixed;
         left: 0;
         bottom: 0;
-        height: 70%;
-        border-radius: 16px 16px 0 0;
-        box-shadow: 0 -2px 10px rgba(0,0,0,0.2);
+        border-radius: 18px 18px 0 0;
+        box-shadow: 0 -2px 10px rgba(0,0,0,0.1);
     }
 }


### PR DESCRIPTION
## Summary
- Show `Lost` instead of `6/6 tries` when a commenter failed the puzzle
- Make the comments header back button transparent on mobile and apply its panel shadow only on small screens
- Track comment outcomes with a `won` flag
- Clear previous question's comments before loading new ones to prevent flicker

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68c037def2088329b9084df6032b8549