### PR TITLE
Remove comments tooltip and adjust cursor

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,7 +52,7 @@
             </div>
             <!-- Inline info shown only after game ends -->
             <div class="question-meta" id="question-meta" style="display: none;">
-                <button class="meta-item" id="comments-btn" data-tooltip="Comments">
+                <button class="meta-item" id="comments-btn">
                     <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#333" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                         <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/>
                     </svg>

--- a/styles.css
+++ b/styles.css
@@ -227,6 +227,12 @@ button#stats-btn {
     opacity: 1;
 }
 
+/* Hide tooltip pseudo-elements when no data-tooltip is present */
+.question-meta .meta-item:not([data-tooltip])::after,
+.question-meta .meta-item:not([data-tooltip])::before {
+    content: none;
+}
+
 /* avg-tries-inline removed */
 
 .source-btn {
@@ -1053,6 +1059,7 @@ button#stats-btn {
     padding: 18.5px 15px;
     outline: none;
     line-height: 1.4;
+    cursor: pointer;
 }
 
 /* Large screens (>768px) - Show images side by side */

--- a/styles.css
+++ b/styles.css
@@ -170,6 +170,7 @@ button#stats-btn {
     gap: 12px;
     font-family: 'Press Start 2P', monospace;
     font-size: 0.8rem;
+    cursor: pointer;
 }
 
 .streak-emoji { 
@@ -1008,7 +1009,6 @@ button#stats-btn {
     padding: 18.5px 15px;
     outline: none;
     line-height: 1.4;
-    cursor: pointer;
 }
 
 /* Large screens (>768px) - Show images side by side */

--- a/styles.css
+++ b/styles.css
@@ -182,57 +182,6 @@ button#stats-btn {
     line-height: 1; 
 }
 
-/* Tooltips for inline meta items (appear below) */
-.question-meta .meta-item::after {
-    content: attr(data-tooltip);
-    position: absolute;
-    top: 100%;
-    left: 50%;
-    transform: translate(-50%, 10px);
-    background: #333;
-    color: #fff;
-    padding: 8px 10px;
-    border-radius: 8px;
-    font-size: 0.675rem;
-    line-height: 1.3;
-    white-space: normal;
-    min-width: 100px;
-    max-width: 200px;
-    text-align: center;
-    opacity: 0;
-    pointer-events: none;
-    transition: opacity 0.15s ease, transform 0.15s ease;
-    z-index: 1000;
-}
-
-.question-meta .meta-item::before {
-    content: '';
-    position: absolute;
-    top: calc(100% - 2px);
-    left: 50%;
-    transform: translateX(-50%);
-    border-width: 6px;
-    border-style: solid;
-    border-color: transparent transparent #333 transparent;
-    opacity: 0;
-    transition: opacity 0.15s ease;
-}
-
-.question-meta .meta-item:hover::after,
-.question-meta .meta-item:hover::before,
-.question-meta .meta-item:focus::after,
-.question-meta .meta-item:focus::before,
-.question-meta .meta-item.show-tooltip::after,
-.question-meta .meta-item.show-tooltip::before {
-    opacity: 1;
-}
-
-/* Hide tooltip pseudo-elements when no data-tooltip is present */
-.question-meta .meta-item:not([data-tooltip])::after,
-.question-meta .meta-item:not([data-tooltip])::before {
-    content: none;
-}
-
 /* avg-tries-inline removed */
 
 .source-btn {


### PR DESCRIPTION
## Summary
- Remove hardcoded "Comments" tooltip from comments button.
- Disable tooltip pseudo-elements when no data-tooltip is present and show pointer cursor over comments input.

## Testing
- `npm test` (fails: Could not read package.json)
- `npm run lint` (fails: Could not read package.json)

------
https://chatgpt.com/codex/tasks/task_e_68c54416096083298d7134e3b555d8bd