### PR TITLE
Integrate strategy tips and calibration settings into How to Play modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -180,16 +180,14 @@
             <div class="modal-content">
                 <h2>How to Play</h2>
                 <div class="accordion" id="help-accordion">
-                    <div class="accordion-item open" id="acc-overview-item">
-                        <button class="accordion-header" id="acc-overview-header" aria-expanded="true" aria-controls="acc-overview-panel">
-                            <span>Overview</span>
+                    <div class="accordion-item" id="acc-calibration-help-item">
+                        <button class="accordion-header" id="acc-calibration-help-header" aria-expanded="false" aria-controls="acc-calibration-help-panel">
+                            <span>Probability Calibration</span>
                             <span class="acc-arrow">></span>
                         </button>
-                        <div class="accordion-panel" id="acc-overview-panel">
-                            <p>Guess the answer to estimation questions in 6 or less tries.</p>
-                            <p>After each guess, you'll see if your answer was too high or too low. An arrow pointing down means that the correct answer is below your guess.</p>
-                            <p>The color of the arrows shows how close you are: orange indicates your guess is within ±50% of the answer, red means it is further away</p>
-                            <p>You win if your guess is within ±20% of the correct answer.</p>
+                        <div class="accordion-panel" id="acc-calibration-help-panel">
+                            <p>Enable probability calibration mode to log your confidence with each guess and track how well your probabilities match reality. A calibration chart showing whether you're over- or under-confident is available on the stats page.</p>
+                            <label><input type="checkbox" id="prob-calibration-checkbox-help" class="prob-calibration-checkbox"> Enable probability calibration mode</label>
                         </div>
                     </div>
                     <div class="accordion-item" id="acc-strategy-item">
@@ -203,14 +201,16 @@
                             <p>Population a little over 100M → about 50M households. Roughly 80% own a car → 40M cars. If cars are replaced about every 10 years, that means roughly 4M new cars sold per year.</p>
                         </div>
                     </div>
-                    <div class="accordion-item" id="acc-calibration-help-item">
-                        <button class="accordion-header" id="acc-calibration-help-header" aria-expanded="false" aria-controls="acc-calibration-help-panel">
-                            <span>Probability Calibration</span>
+                    <div class="accordion-item open" id="acc-overview-item">
+                        <button class="accordion-header" id="acc-overview-header" aria-expanded="true" aria-controls="acc-overview-panel">
+                            <span>Overview</span>
                             <span class="acc-arrow">></span>
                         </button>
-                        <div class="accordion-panel" id="acc-calibration-help-panel">
-                            <p>Enable probability calibration mode to log your confidence with each guess and track how well your probabilities match reality. A calibration chart showing whether you're over- or under-confident is available on the stats page.</p>
-                            <label><input type="checkbox" id="prob-calibration-checkbox-help" class="prob-calibration-checkbox"> Enable probability calibration mode</label>
+                        <div class="accordion-panel" id="acc-overview-panel">
+                            <p>Guess the answer to estimation questions in 6 or less tries.</p>
+                            <p>After each guess, you'll see if your answer was too high or too low. An arrow pointing down means that the correct answer is below your guess.</p>
+                            <p>The color of the arrows shows how close you are: orange indicates your guess is within ±50% of the answer, red means it is further away</p>
+                            <p>You win if your guess is within ±20% of the correct answer.</p>
                         </div>
                     </div>
                 </div>

--- a/index.html
+++ b/index.html
@@ -179,22 +179,42 @@
         <div class="modal" id="help-modal">
             <div class="modal-content">
                 <h2>How to Play</h2>
-                <p>Guess the answer to estimation questions in 6 or less tries.</p>
-                <p>After each guess, you'll see if your answer was too high or too low. An arrow pointing down means that the correct answer is below your guess.</p>
-                <p>The color of the arrows shows how close you are: orange indicates your guess is within ±50% of the answer, red means it is further away</p>
-                <p>You win if your guess is within ±20% of the correct answer.</p>
+                <div class="accordion" id="help-accordion">
+                    <div class="accordion-item open" id="acc-overview-item">
+                        <button class="accordion-header" id="acc-overview-header" aria-expanded="true" aria-controls="acc-overview-panel">
+                            <span>Overview</span>
+                            <span class="acc-arrow">></span>
+                        </button>
+                        <div class="accordion-panel" id="acc-overview-panel">
+                            <p>Guess the answer to estimation questions in 6 or less tries.</p>
+                            <p>After each guess, you'll see if your answer was too high or too low. An arrow pointing down means that the correct answer is below your guess.</p>
+                            <p>The color of the arrows shows how close you are: orange indicates your guess is within ±50% of the answer, red means it is further away</p>
+                            <p>You win if your guess is within ±20% of the correct answer.</p>
+                        </div>
+                    </div>
+                    <div class="accordion-item" id="acc-strategy-item">
+                        <button class="accordion-header" id="acc-strategy-header" aria-expanded="false" aria-controls="acc-strategy-panel">
+                            <span>Strategy tip</span>
+                            <span class="acc-arrow">></span>
+                        </button>
+                        <div class="accordion-panel" id="acc-strategy-panel">
+                            <p>Make a Fermi estimate: break the problem into simple factors, choose round numbers, then multiply.</p>
+                            <p>Example: How many pizzas are eaten in NYC per day?</p>
+                            <p>Population ≈ 8M. About half eat pizza weekly → 4M people. Typical serving ≈ 2 slices per person per week → 8M slices/week. Per day ≈ 8M/7 ≈ 1.1M slices/day. ≈ 8 slices/pizza → ~140k pizzas/day.</p>
+                        </div>
+                    </div>
+                    <div class="accordion-item" id="acc-calibration-help-item">
+                        <button class="accordion-header" id="acc-calibration-help-header" aria-expanded="false" aria-controls="acc-calibration-help-panel">
+                            <span>Probability Calibration</span>
+                            <span class="acc-arrow">></span>
+                        </button>
+                        <div class="accordion-panel" id="acc-calibration-help-panel">
+                            <p>Enable probability calibration mode to log your confidence with each guess and track how well your probabilities match reality.</p>
+                            <label><input type="checkbox" id="prob-calibration-checkbox-help" class="prob-calibration-checkbox"> Enable probability calibration mode</label>
+                        </div>
+                    </div>
+                </div>
                 <button id="close-help-btn" class="close-btn">Close</button>
-            </div>
-        </div>
-
-        <!-- Strategy Tips Modal -->
-        <div class="modal" id="strategy-modal">
-            <div class="modal-content">
-                <h2>Strategy tips</h2>
-                <p>Make a Fermi estimate: break the problem into simple factors, choose round numbers, then multiply.</p>
-                <p>Example: How many pizzas are eaten in NYC per day?</p>
-                <p>Population ≈ 8M. About half eat pizza weekly → 4M people. Typical serving ≈ 2 slices per person per week → 8M slices/week. Per day ≈ 8M/7 ≈ 1.1M slices/day. ≈ 8 slices/pizza → ~140k pizzas/day.</p>
-                <button id="close-strategy-btn" class="close-btn">Close</button>
             </div>
         </div>
 

--- a/index.html
+++ b/index.html
@@ -199,8 +199,8 @@
                         </button>
                         <div class="accordion-panel" id="acc-strategy-panel">
                             <p>Make a Fermi estimate: break the problem into simple factors, choose round numbers, then multiply.</p>
-                            <p>Example: How many pizzas are eaten in NYC per day?</p>
-                            <p>Population ≈ 8M. About half eat pizza weekly → 4M people. Typical serving ≈ 2 slices per person per week → 8M slices/week. Per day ≈ 8M/7 ≈ 1.1M slices/day. ≈ 8 slices/pizza → ~140k pizzas/day.</p>
+                            <p>Example: How many new cars are sold annually in Japan?</p>
+                            <p>Population a little over 100M → about 50M households. Roughly 80% own a car → 40M cars. If cars are replaced about every 10 years, that means roughly 4M new cars sold per year.</p>
                         </div>
                     </div>
                     <div class="accordion-item" id="acc-calibration-help-item">
@@ -209,7 +209,7 @@
                             <span class="acc-arrow">></span>
                         </button>
                         <div class="accordion-panel" id="acc-calibration-help-panel">
-                            <p>Enable probability calibration mode to log your confidence with each guess and track how well your probabilities match reality.</p>
+                            <p>Enable probability calibration mode to log your confidence with each guess and track how well your probabilities match reality. A calibration chart showing whether you're over- or under-confident is available on the stats page.</p>
                             <label><input type="checkbox" id="prob-calibration-checkbox-help" class="prob-calibration-checkbox"> Enable probability calibration mode</label>
                         </div>
                     </div>

--- a/script.js
+++ b/script.js
@@ -1704,6 +1704,16 @@ function startNewGameFromModal() {
 
 // Show help modal
 function showHelp() {
+    document.querySelectorAll('#help-accordion .accordion-item').forEach(item => {
+        const header = item.querySelector('.accordion-header');
+        if (item.id === 'acc-overview-item') {
+            item.classList.add('open');
+            header.setAttribute('aria-expanded', 'true');
+        } else {
+            item.classList.remove('open');
+            header.setAttribute('aria-expanded', 'false');
+        }
+    });
     helpModal.style.display = 'block';
 }
 

--- a/script.js
+++ b/script.js
@@ -1704,16 +1704,6 @@ function startNewGameFromModal() {
 
 // Show help modal
 function showHelp() {
-    document.querySelectorAll('#help-accordion .accordion-item').forEach(item => {
-        const header = item.querySelector('.accordion-header');
-        if (item.id === 'acc-overview-item') {
-            item.classList.add('open');
-            header.setAttribute('aria-expanded', 'true');
-        } else {
-            item.classList.remove('open');
-            header.setAttribute('aria-expanded', 'false');
-        }
-    });
     helpModal.style.display = 'block';
 }
 

--- a/script.js
+++ b/script.js
@@ -970,9 +970,7 @@ const statsBtn = document.getElementById('stats-btn');
 const helpModal = document.getElementById('help-modal');
 const statsModal = document.getElementById('stats-modal');
 const questionsModal = document.getElementById('questions-modal');
-const strategyModal = document.getElementById('strategy-modal');
 const strategyTipsBtn = document.getElementById('strategy-tips-btn');
-const closeStrategyBtn = document.getElementById('close-strategy-btn');
 // Hint elements
 const hintModalBtn = document.getElementById('hint-modal-btn');
 const questionsList = document.getElementById('questions-list');
@@ -1707,11 +1705,6 @@ function startNewGameFromModal() {
 // Show help modal
 function showHelp() {
     helpModal.style.display = 'block';
-}
-
-// Show strategy modal
-function showStrategy() {
-    if (strategyModal) strategyModal.style.display = 'block';
 }
 
 // Show stats modal
@@ -2986,73 +2979,27 @@ function setupEventListeners() {
             }
             sourceModal.style.display = 'block';
         });
-        // Accordion toggles
-        const accSourceItem = document.getElementById('acc-source-item');
-        const accSourceHeader = document.getElementById('acc-source-header');
-        const accStatsItem = document.getElementById('acc-stats-item');
-        const accStatsHeader = document.getElementById('acc-stats-header');
-        const accInitialItem = document.getElementById('acc-initial-item');
-        const accInitialHeader = document.getElementById('acc-initial-header');
-        if (accSourceHeader && accSourceItem) {
-            accSourceHeader.addEventListener('click', () => {
-                const isOpen = accSourceItem.classList.contains('open');
-                if (isOpen) accSourceItem.classList.remove('open');
-                else accSourceItem.classList.add('open');
-            });
-        }
-        if (accStatsHeader && accStatsItem) {
-            accStatsHeader.addEventListener('click', () => {
-                const isOpen = accStatsItem.classList.contains('open');
-                if (isOpen) accStatsItem.classList.remove('open');
-                else accStatsItem.classList.add('open');
-            });
-        }
-        if (accInitialHeader && accInitialItem) {
-            accInitialHeader.addEventListener('click', () => {
-                const isOpen = accInitialItem.classList.contains('open');
-                if (isOpen) accInitialItem.classList.remove('open');
-                else accInitialItem.classList.add('open');
-            });
-        }
     }
 
-    const accStatsGridItem = document.getElementById('acc-statsgrid-item');
-    const accStatsGridHeader = document.getElementById('acc-statsgrid-header');
-    if (accStatsGridHeader && accStatsGridItem) {
-        accStatsGridHeader.addEventListener('click', () => {
-            const isOpen = accStatsGridItem.classList.contains('open');
-            if (isOpen) accStatsGridItem.classList.remove('open');
-            else accStatsGridItem.classList.add('open');
+    // Accordion toggles
+    document.querySelectorAll('.accordion-header').forEach(header => {
+        header.addEventListener('click', () => {
+            const item = header.parentElement;
+            const isOpen = item.classList.contains('open');
+            if (isOpen) {
+                item.classList.remove('open');
+                header.setAttribute('aria-expanded', 'false');
+            } else {
+                item.classList.add('open');
+                header.setAttribute('aria-expanded', 'true');
+            }
         });
-    }
-
-    const accDistributionItem = document.getElementById('acc-distribution-item');
-    const accDistributionHeader = document.getElementById('acc-distribution-header');
-    if (accDistributionHeader && accDistributionItem) {
-        accDistributionHeader.addEventListener('click', () => {
-            const isOpen = accDistributionItem.classList.contains('open');
-            if (isOpen) accDistributionItem.classList.remove('open');
-            else accDistributionItem.classList.add('open');
-        });
-    }
-
-    const accCalibrationItem = document.getElementById('acc-calibration-item');
-    const accCalibrationHeader = document.getElementById('acc-calibration-header');
-    if (accCalibrationHeader && accCalibrationItem) {
-        accCalibrationHeader.addEventListener('click', () => {
-            const isOpen = accCalibrationItem.classList.contains('open');
-            if (isOpen) accCalibrationItem.classList.remove('open');
-            else accCalibrationItem.classList.add('open');
-        });
-    }
+    });
     
     // Close buttons
     closeHelpBtn.addEventListener('click', () => closeModal(helpModal));
     closeStatsBtn.addEventListener('click', () => closeModal(statsModal));
     closeQuestionsBtn.addEventListener('click', () => closeModal(questionsModal));
-    if (closeStrategyBtn) {
-        closeStrategyBtn.addEventListener('click', () => closeModal(strategyModal));
-    }
 
     // Comment buttons
     if (commentsBtn) commentsBtn.addEventListener('click', openComments);
@@ -3072,7 +3019,7 @@ function setupEventListeners() {
     shareStatsBtn.addEventListener('click', shareStats);
         
     // Close modals when clicking outside (desktop + mobile)
-    [helpModal, statsModal, questionsModal, strategyModal, sourceModal].forEach(modal => {
+    [helpModal, statsModal, questionsModal, sourceModal].forEach(modal => {
         ['click', 'touchend'].forEach(event => {
             modal.addEventListener(event, e => e.target === modal && closeModal(modal));
         });


### PR DESCRIPTION
## Summary
- Move core instructions into an Overview accordion within the How to Play modal
- Add Probability Calibration accordion with checkbox to enable/disable the mode
- Simplify accordion handling by using a generic aria-expanded toggle

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c571d06860832986a42344c812378a