### PR TITLE
Remove mobile no-scroll handling causing Safari issues

### DIFF
--- a/script.js
+++ b/script.js
@@ -409,23 +409,15 @@ function subscribeToComments(questionDate) {
         .subscribe();
 }
 
-let bodyScrollY = 0;
-
 function openComments() {
     if (!commentsSection) return;
     loadComments();
-    bodyScrollY = window.scrollY;
-    document.body.style.position = 'fixed';
-    document.body.style.top = `-${bodyScrollY}px`;
     commentsSection.classList.add('open');
 }
 
 function closeComments() {
     if (!commentsSection) return;
     commentsSection.classList.remove('open');
-    document.body.style.position = '';
-    document.body.style.top = '';
-    window.scrollTo(0, bodyScrollY);
 }
 
 // Update the average tries display in the inline meta row

--- a/script.js
+++ b/script.js
@@ -409,15 +409,23 @@ function subscribeToComments(questionDate) {
         .subscribe();
 }
 
+let bodyScrollY = 0;
+
 function openComments() {
     if (!commentsSection) return;
     loadComments();
+    bodyScrollY = window.scrollY;
+    document.body.style.position = 'fixed';
+    document.body.style.top = `-${bodyScrollY}px`;
     commentsSection.classList.add('open');
 }
 
 function closeComments() {
     if (!commentsSection) return;
     commentsSection.classList.remove('open');
+    document.body.style.position = '';
+    document.body.style.top = '';
+    window.scrollTo(0, bodyScrollY);
 }
 
 // Update the average tries display in the inline meta row

--- a/script.js
+++ b/script.js
@@ -413,13 +413,11 @@ function openComments() {
     if (!commentsSection) return;
     loadComments();
     commentsSection.classList.add('open');
-    document.body.classList.add('no-scroll');
 }
 
 function closeComments() {
     if (!commentsSection) return;
     commentsSection.classList.remove('open');
-    document.body.classList.remove('no-scroll');
 }
 
 // Update the average tries display in the inline meta row

--- a/styles.css
+++ b/styles.css
@@ -938,15 +938,17 @@ button#stats-btn {
 /* Comments section */
 .comments-section {
     display: none;
-    position: absolute;
+    position: fixed;
     top: 0;
     left: 0;
     width: 100%;
-    height: 100%;
+    height: 100vh;
     background: #fff;
     z-index: 1000;
     flex-direction: column;
     border-radius: 18px;
+    overflow: hidden;
+    overscroll-behavior: contain;
 }
 
 .comments-section.open {

--- a/styles.css
+++ b/styles.css
@@ -1046,9 +1046,6 @@ button#stats-btn {
         background: repeating-linear-gradient(to bottom, rgb(0 0 0 / 1%) 0px, rgb(0 0 0 / 1%) 1px, transparent 2px, transparent 4px), linear-gradient(to bottom, rgb(16 163 127 / 5%) 0px, rgb(90 97 255 / 5%) 120px, rgb(0 204 255 / 2%) 200px, rgba(255, 255, 255, 0.95) 290px, #ffffff 100%);
         padding: 0px 18px;
     }
-    body.no-scroll {
-    overflow: hidden;
-    }
     .icon-button {
         background: #f4f8fa;
     }


### PR DESCRIPTION
## Summary
- Remove `body.no-scroll` overflow restriction from mobile styles
- Drop no-scroll class toggling when opening/closing comments to prevent scroll glitches

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c59a0e4cf483298fe17474cf854c68