### PR TITLE
Enable calibration by default and guide confidence input

### DIFF
--- a/index.html
+++ b/index.html
@@ -140,7 +140,7 @@
                             <option value="90">90%</option>
                             <option value="100">100%</option>
                         </select>
-                        <button id="confidence-button" type="button" aria-haspopup="listbox" aria-expanded="false">50%</button>
+                        <button id="confidence-button" type="button" aria-haspopup="listbox" aria-expanded="false" data-tooltip="Choose how confident you are that your answer is correct">50%<span class="confidence-caret">&gt;</span></button>
                         <div id="confidence-menu" class="confidence-menu" role="listbox">
                             <button type="button" data-value="10" role="option">10%</button>
                             <button type="button" data-value="20" role="option">20%</button>

--- a/script.js
+++ b/script.js
@@ -454,7 +454,8 @@ let stats = {
     calibrationData: []
 };
 
-let calibrationEnabled = false;
+// Enable probability calibration mode by default
+let calibrationEnabled = true;
 
 // Database of Fermi questions with dates
 const fermiQuestions = [
@@ -1985,7 +1986,13 @@ function loadCompletedQuestions() {
 }
 
 function loadCalibrationSetting() {
-    calibrationEnabled = localStorage.getItem('fermiCalibrationEnabled') === 'true';
+    const stored = localStorage.getItem('fermiCalibrationEnabled');
+    if (stored === null) {
+        calibrationEnabled = true;
+        localStorage.setItem('fermiCalibrationEnabled', 'true');
+    } else {
+        calibrationEnabled = stored === 'true';
+    }
     calibrationCheckboxes.forEach(cb => {
         cb.checked = calibrationEnabled;
     });
@@ -2802,8 +2809,23 @@ function setupEventListeners() {
         }
     });
     
-    // Format input with commas as user types
+    // Format input with commas as user types and show confidence tooltip once
     guessInput.addEventListener('input', (e) => {
+        if (
+            calibrationEnabled &&
+            confidenceButton &&
+            confidenceButton.style.display !== 'none' &&
+            localStorage.getItem('fermiConfidenceTooltipShown') !== 'true'
+        ) {
+            localStorage.setItem('fermiConfidenceTooltipShown', 'true');
+            confidenceButton.setAttribute(
+                'data-tooltip',
+                'Choose how confident you are that your answer is correct'
+            );
+            confidenceButton.classList.add('show-tooltip');
+            setTimeout(() => confidenceButton.classList.remove('show-tooltip'), 3000);
+        }
+
         const input = e.target;
         const value = input.value.replace(/[^\d]/g, ''); // Keep only digits
 

--- a/script.js
+++ b/script.js
@@ -2818,10 +2818,6 @@ function setupEventListeners() {
             localStorage.getItem('fermiConfidenceTooltipShown') !== 'true'
         ) {
             localStorage.setItem('fermiConfidenceTooltipShown', 'true');
-            confidenceButton.setAttribute(
-                'data-tooltip',
-                'Choose how confident you are that your answer is correct'
-            );
             confidenceButton.classList.add('show-tooltip');
             setTimeout(() => confidenceButton.classList.remove('show-tooltip'), 3000);
         }

--- a/styles.css
+++ b/styles.css
@@ -691,8 +691,7 @@ button#stats-btn {
     position: relative;
 }
 
-#confidence-button::after {
-    content: '>';
+#confidence-button .confidence-caret {
     position: absolute;
     right: 4px;
     top: 50%;

--- a/styles.css
+++ b/styles.css
@@ -514,6 +514,44 @@ button#stats-btn {
     opacity: 1;
 }
 
+#confidence-button::after {
+    content: attr(data-tooltip);
+    position: absolute;
+    bottom: calc(100% + 12px);
+    left: 50%;
+    transform: translateX(-50%);
+    background: #333;
+    color: #fff;
+    padding: 10px 14px;
+    border-radius: 8px;
+    font-size: 0.675rem;
+    white-space: nowrap;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.15s ease, transform 0.15s ease;
+    z-index: 1000;
+    line-height: 1.4;
+}
+
+#confidence-button::before {
+    content: '';
+    position: absolute;
+    bottom: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    border-width: 6px;
+    border-style: solid;
+    border-color: rgba(51, 51, 51, 0.95) transparent transparent transparent;
+    opacity: 0;
+    transition: opacity 0.15s ease;
+    z-index: 1000;
+}
+
+#confidence-button.show-tooltip::after,
+#confidence-button.show-tooltip::before {
+    opacity: 1;
+}
+
 .feedback-button.high {
     background-color: #fe4c4c;
     color: white;


### PR DESCRIPTION
## Summary
- Enable probability calibration mode by default and persist the setting in local storage.
- Show a brief tooltip over the confidence selector the first time a user types a guess.
- Style the confidence button to support programmatic tooltips.

## Testing
- `node --check script.js`
- `npm test` *(fails: ENOENT, no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5aacc849883298f29f95153f36315