### PR TITLE
Enable calibration mode by default

### DIFF
--- a/index.html
+++ b/index.html
@@ -188,7 +188,7 @@
                         <div class="accordion-panel" id="acc-calibration-help-panel">
                             <p>When the probability calibration mode is enabled, you are able to log your confidence with each guess and track how well your probabilities match reality.</p>
                             <p>A calibration chart showing whether you're over- or underconfident is available on the stats page.</p>
-                            <label><input type="checkbox" id="prob-calibration-checkbox-help" class="prob-calibration-checkbox"> Disable probability calibration mode</label>
+                            <label><input type="checkbox" id="prob-calibration-checkbox-help" class="prob-calibration-checkbox" checked> Enable probability calibration mode</label>
                         </div>
                     </div>
                     <div class="accordion-item" id="acc-strategy-item">
@@ -374,7 +374,7 @@
                         <div class="accordion-panel" id="acc-calibration-panel">
                             <div class="calibration-options">
                                 <label>
-                                    <input type="checkbox" id="prob-calibration-checkbox-stats" class="prob-calibration-checkbox"> Disable probability calibration mode
+                                    <input type="checkbox" id="prob-calibration-checkbox-stats" class="prob-calibration-checkbox" checked> Enable probability calibration mode
                                 </label>
                                 <label>
                                     <input type="checkbox" id="first-guess-checkbox"> Only count first guesses

--- a/index.html
+++ b/index.html
@@ -188,7 +188,7 @@
                         <div class="accordion-panel" id="acc-calibration-help-panel">
                             <p>When the probability calibration mode is enabled, you are able to log your confidence with each guess and track how well your probabilities match reality.</p>
                             <p>A calibration chart showing whether you're over- or underconfident is available on the stats page.</p>
-                            <label><input type="checkbox" id="prob-calibration-checkbox-help" class="prob-calibration-checkbox"> Enable probability calibration mode</label>
+                            <label><input type="checkbox" id="prob-calibration-checkbox-help" class="prob-calibration-checkbox"> Disable probability calibration mode</label>
                         </div>
                     </div>
                     <div class="accordion-item" id="acc-strategy-item">
@@ -374,10 +374,10 @@
                         <div class="accordion-panel" id="acc-calibration-panel">
                             <div class="calibration-options">
                                 <label>
-                                    <input type="checkbox" id="prob-calibration-checkbox-stats" class="prob-calibration-checkbox"> Enable probability calibration mode
+                                    <input type="checkbox" id="prob-calibration-checkbox-stats" class="prob-calibration-checkbox"> Disable probability calibration mode
                                 </label>
                                 <label>
-                                    <input type="checkbox" id="first-guess-checkbox" checked> Only count first guesses
+                                    <input type="checkbox" id="first-guess-checkbox"> Only count first guesses
                                 </label>
                             </div>
                             <p class="calibration-note">No data yet</p>

--- a/script.js
+++ b/script.js
@@ -1988,7 +1988,7 @@ function loadCalibrationSetting() {
     const storedCalibration = localStorage.getItem('fermiCalibrationEnabled');
     calibrationEnabled = storedCalibration !== 'false';
     calibrationCheckboxes.forEach(cb => {
-        cb.checked = !calibrationEnabled;
+        cb.checked = calibrationEnabled;
     });
     const savedFirstOnly = localStorage.getItem('fermiFirstGuessOnly');
     if (firstGuessCheckbox && savedFirstOnly !== null) {
@@ -2002,7 +2002,7 @@ function setCalibrationEnabled(enabled) {
     calibrationEnabled = enabled;
     localStorage.setItem('fermiCalibrationEnabled', enabled ? 'true' : 'false');
     calibrationCheckboxes.forEach(cb => {
-        cb.checked = !enabled;
+        cb.checked = enabled;
     });
     updateConfidenceInputVisibility();
 }
@@ -2848,7 +2848,7 @@ function setupEventListeners() {
     if (calibrationCheckboxes.length) {
         calibrationCheckboxes.forEach(cb => {
             cb.addEventListener('change', (e) => {
-                setCalibrationEnabled(!e.target.checked);
+                setCalibrationEnabled(e.target.checked);
             });
         });
     }

--- a/script.js
+++ b/script.js
@@ -1985,9 +1985,10 @@ function loadCompletedQuestions() {
 }
 
 function loadCalibrationSetting() {
-    calibrationEnabled = localStorage.getItem('fermiCalibrationEnabled') === 'true';
+    const storedCalibration = localStorage.getItem('fermiCalibrationEnabled');
+    calibrationEnabled = storedCalibration !== 'false';
     calibrationCheckboxes.forEach(cb => {
-        cb.checked = calibrationEnabled;
+        cb.checked = !calibrationEnabled;
     });
     const savedFirstOnly = localStorage.getItem('fermiFirstGuessOnly');
     if (firstGuessCheckbox && savedFirstOnly !== null) {
@@ -2001,7 +2002,7 @@ function setCalibrationEnabled(enabled) {
     calibrationEnabled = enabled;
     localStorage.setItem('fermiCalibrationEnabled', enabled ? 'true' : 'false');
     calibrationCheckboxes.forEach(cb => {
-        cb.checked = enabled;
+        cb.checked = !enabled;
     });
     updateConfidenceInputVisibility();
 }
@@ -2847,7 +2848,7 @@ function setupEventListeners() {
     if (calibrationCheckboxes.length) {
         calibrationCheckboxes.forEach(cb => {
             cb.addEventListener('change', (e) => {
-                setCalibrationEnabled(e.target.checked);
+                setCalibrationEnabled(!e.target.checked);
             });
         });
     }


### PR DESCRIPTION
## Summary
- Flip probability calibration setting so it starts enabled and checkboxes disable it
- Stop enabling the "only count first guesses" option by default

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5c2da184c832996582ab79b1704bb