### PR TITLE
Add dismissible probability calibration banner

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,6 +32,10 @@
                 </button>
             </div>
         </header>
+        <div id="calibration-banner" class="calibration-banner" style="display: none;">
+            <span class="banner-text">You can log your confidence with each guess. A calibration chart showing whether you're over- or underconfident is available on the stats page.</span>
+            <button id="calibration-banner-close" class="banner-close" aria-label="Close">×</button>
+        </div>
     <div class="game-container">
         <!-- Question Display -->
         <div class="question-container">

--- a/index.html
+++ b/index.html
@@ -32,10 +32,6 @@
                 </button>
             </div>
         </header>
-        <div id="calibration-banner" class="calibration-banner" style="display: none;">
-            <span class="banner-text">You can log your confidence with each guess. A calibration chart showing whether you're over- or underconfident is available on the stats page.</span>
-            <button id="calibration-banner-close" class="banner-close" aria-label="Close">×</button>
-        </div>
     <div class="game-container">
         <!-- Question Display -->
         <div class="question-container">
@@ -131,7 +127,7 @@
                         inputmode="numeric"
                         pattern="[0-9,]*"
                     >
-                    <div class="confidence-wrapper">
+                    <div class="confidence-wrapper" data-tooltip="How confident are you that your guess is correct?">
                         <select id="confidence-input">
                             <option value="10">10%</option>
                             <option value="20">20%</option>

--- a/script.js
+++ b/script.js
@@ -1003,6 +1003,20 @@ const commentInput = document.getElementById('comment-input');
 const commentSubmitBtn = document.getElementById('comment-submit-btn');
 const commentCountEl = document.getElementById('comment-count');
 
+// Calibration banner
+function initCalibrationBanner() {
+    const banner = document.getElementById('calibration-banner');
+    const closeBtn = document.getElementById('calibration-banner-close');
+    if (!banner || !closeBtn) return;
+    const dismissed = localStorage.getItem('calibrationBannerDismissed');
+    if (dismissed === 'true') return;
+    banner.style.display = 'flex';
+    closeBtn.addEventListener('click', () => {
+        banner.style.display = 'none';
+        localStorage.setItem('calibrationBannerDismissed', 'true');
+    });
+}
+
 // Initialize game
 function initGame() {
     // Initialize Supabase first
@@ -1011,6 +1025,7 @@ function initGame() {
     loadStats();
     loadCompletedQuestions();
     loadCalibrationSetting();
+    initCalibrationBanner();
 
     // If URL has a specific question date, navigate to it first
     let navigatedFromURL = false;

--- a/script.js
+++ b/script.js
@@ -961,6 +961,7 @@ const guessInput = document.getElementById('guess-input');
 const confidenceInput = document.getElementById('confidence-input');
 const confidenceButton = document.getElementById('confidence-button');
 const confidenceMenu = document.getElementById('confidence-menu');
+const confidenceWrapper = document.querySelector('.confidence-wrapper');
 const submitBtn = document.getElementById('submit-btn');
 const sendIcon = `\
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
@@ -1003,18 +1004,23 @@ const commentInput = document.getElementById('comment-input');
 const commentSubmitBtn = document.getElementById('comment-submit-btn');
 const commentCountEl = document.getElementById('comment-count');
 
-// Calibration banner
-function initCalibrationBanner() {
-    const banner = document.getElementById('calibration-banner');
-    const closeBtn = document.getElementById('calibration-banner-close');
-    if (!banner || !closeBtn) return;
-    const dismissed = localStorage.getItem('calibrationBannerDismissed');
+
+// Confidence tooltip
+function initConfidenceTooltip() {
+    if (!confidenceWrapper) return;
+    const dismissed = localStorage.getItem('confidenceTooltipDismissed');
     if (dismissed === 'true') return;
-    banner.style.display = 'flex';
-    closeBtn.addEventListener('click', () => {
-        banner.style.display = 'none';
-        localStorage.setItem('calibrationBannerDismissed', 'true');
-    });
+    confidenceWrapper.classList.add('show-tooltip');
+    const hideTooltip = () => {
+        confidenceWrapper.classList.remove('show-tooltip');
+        localStorage.setItem('confidenceTooltipDismissed', 'true');
+        document.removeEventListener('mousedown', hideTooltip);
+        document.removeEventListener('keydown', hideTooltip);
+        document.removeEventListener('touchstart', hideTooltip);
+    };
+    document.addEventListener('mousedown', hideTooltip, { once: true });
+    document.addEventListener('keydown', hideTooltip, { once: true });
+    document.addEventListener('touchstart', hideTooltip, { once: true });
 }
 
 // Initialize game
@@ -1025,7 +1031,7 @@ function initGame() {
     loadStats();
     loadCompletedQuestions();
     loadCalibrationSetting();
-    initCalibrationBanner();
+    initConfidenceTooltip();
 
     // If URL has a specific question date, navigate to it first
     let navigatedFromURL = false;

--- a/styles.css
+++ b/styles.css
@@ -76,6 +76,33 @@ button#stats-btn {
     padding-right: 10px;
 }
 
+/* Calibration banner */
+.calibration-banner {
+    display: none;
+    max-width: 500px;
+    margin: 0 auto 16px;
+    background-color: #fff3cd;
+    border: 2px solid #ffeeba;
+    border-radius: 8px;
+    padding: 12px 16px;
+    position: relative;
+    font-size: 0.8rem;
+}
+
+.calibration-banner .banner-text {
+    margin-right: 24px;
+}
+
+.calibration-banner .banner-close {
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    background: none;
+    border: none;
+    font-size: 1rem;
+    cursor: pointer;
+}
+
 /* Question Container */
 .question-container {
     position: relative;

--- a/styles.css
+++ b/styles.css
@@ -76,33 +76,6 @@ button#stats-btn {
     padding-right: 10px;
 }
 
-/* Calibration banner */
-.calibration-banner {
-    display: none;
-    max-width: 500px;
-    margin: 0 auto 16px;
-    background-color: #fff3cd;
-    border: 2px solid #ffeeba;
-    border-radius: 8px;
-    padding: 12px 16px;
-    position: relative;
-    font-size: 0.8rem;
-}
-
-.calibration-banner .banner-text {
-    margin-right: 24px;
-}
-
-.calibration-banner .banner-close {
-    position: absolute;
-    top: 8px;
-    right: 8px;
-    background: none;
-    border: none;
-    font-size: 1rem;
-    cursor: pointer;
-}
-
 /* Question Container */
 .question-container {
     position: relative;
@@ -659,6 +632,44 @@ button#stats-btn {
 
 .confidence-wrapper {
     position: relative;
+}
+
+.confidence-wrapper::after {
+    content: attr(data-tooltip);
+    position: absolute;
+    bottom: calc(100% + 12px);
+    left: 50%;
+    transform: translateX(-50%);
+    background: #333;
+    color: #fff;
+    padding: 10px 14px;
+    border-radius: 8px;
+    font-size: 0.675rem;
+    white-space: nowrap;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.15s ease, transform 0.15s ease;
+    z-index: 1000;
+    line-height: 1.4;
+}
+
+.confidence-wrapper::before {
+    content: '';
+    position: absolute;
+    bottom: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    border-width: 6px;
+    border-style: solid;
+    border-color: rgba(51, 51, 51, 0.95) transparent transparent transparent;
+    opacity: 0;
+    transition: opacity 0.15s ease;
+    z-index: 1000;
+}
+
+.confidence-wrapper.show-tooltip::after,
+.confidence-wrapper.show-tooltip::before {
+    opacity: 1;
 }
 
 #confidence-button {

--- a/styles.css
+++ b/styles.css
@@ -645,12 +645,14 @@ button#stats-btn {
     padding: 10px 14px;
     border-radius: 8px;
     font-size: 0.675rem;
-    white-space: nowrap;
+    width: 100px;
+    white-space: normal;
     opacity: 0;
     pointer-events: none;
     transition: opacity 0.15s ease, transform 0.15s ease;
     z-index: 1000;
     line-height: 1.4;
+    text-align: center;
 }
 
 .confidence-wrapper::before {


### PR DESCRIPTION
## Summary
- Introduce a calibration banner that promotes the new probability calibration mode
- Persist banner dismissal in local storage
- Style banner and close button for consistency with existing UI

## Testing
- `npm test` (fails: ENOENT, could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68c68e52c06c8329b1b4fb18fc7d3c58