### PR TITLE
feat: add quick guess controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -127,35 +127,44 @@
                         inputmode="numeric"
                         pattern="[0-9,]*"
                     >
-                    <div class="confidence-wrapper" data-tooltip="How confident are you that your guess is correct?">
-                        <select id="confidence-input">
-                            <option value="10">10%</option>
-                            <option value="20">20%</option>
-                            <option value="30">30%</option>
-                            <option value="40">40%</option>
-                            <option value="50" selected>50%</option>
-                            <option value="60">60%</option>
-                            <option value="70">70%</option>
-                            <option value="80">80%</option>
-                            <option value="90">90%</option>
-                            <option value="100">100%</option>
-                        </select>
-                        <button id="confidence-button" type="button" aria-haspopup="listbox" aria-expanded="false">50%</button>
-                        <div id="confidence-menu" class="confidence-menu" role="listbox">
-                            <button type="button" data-value="10" role="option">10%</button>
-                            <button type="button" data-value="20" role="option">20%</button>
-                            <button type="button" data-value="30" role="option">30%</button>
-                            <button type="button" data-value="40" role="option">40%</button>
-                            <button type="button" data-value="50" role="option" class="selected">50%</button>
-                            <button type="button" data-value="60" role="option">60%</button>
-                            <button type="button" data-value="70" role="option">70%</button>
-                            <button type="button" data-value="80" role="option">80%</button>
-                            <button type="button" data-value="90" role="option">90%</button>
-                            <button type="button" data-value="100" role="option">100%</button>
+                    <div class="input-actions">
+                        <div class="quick-buttons">
+                            <button type="button" class="quick-btn" data-value="10000000">+10M</button>
+                            <button type="button" class="quick-btn" data-value="100000000">+100M</button>
+                            <button type="button" class="quick-btn" data-value="1000000000">+1B</button>
+                        </div>
+                        <div class="action-right">
+                            <div class="confidence-wrapper" data-tooltip="How confident are you that your guess is correct?">
+                                <select id="confidence-input">
+                                    <option value="10">10%</option>
+                                    <option value="20">20%</option>
+                                    <option value="30">30%</option>
+                                    <option value="40">40%</option>
+                                    <option value="50" selected>50%</option>
+                                    <option value="60">60%</option>
+                                    <option value="70">70%</option>
+                                    <option value="80">80%</option>
+                                    <option value="90">90%</option>
+                                    <option value="100">100%</option>
+                                </select>
+                                <button id="confidence-button" type="button" aria-haspopup="listbox" aria-expanded="false">50%</button>
+                                <div id="confidence-menu" class="confidence-menu" role="listbox">
+                                    <button type="button" data-value="10" role="option">10%</button>
+                                    <button type="button" data-value="20" role="option">20%</button>
+                                    <button type="button" data-value="30" role="option">30%</button>
+                                    <button type="button" data-value="40" role="option">40%</button>
+                                    <button type="button" data-value="50" role="option" class="selected">50%</button>
+                                    <button type="button" data-value="60" role="option">60%</button>
+                                    <button type="button" data-value="70" role="option">70%</button>
+                                    <button type="button" data-value="80" role="option">80%</button>
+                                    <button type="button" data-value="90" role="option">90%</button>
+                                    <button type="button" data-value="100" role="option">100%</button>
+                                </div>
+                            </div>
+                            <button id="submit-btn" class="submit-btn">Submit</button>
                         </div>
                     </div>
                 </div>
-                <button id="submit-btn" class="submit-btn">Submit</button>
             </div>
         </div>
 

--- a/index.html
+++ b/index.html
@@ -129,7 +129,8 @@
                     >
                     <div class="input-actions">
                         <div class="quick-buttons">
-                            <button type="button" class="quick-btn" data-value="1000000">+1M</button>
+                            <button type="button" class="quick-btn" data-value="10000000">+10M</button>
+                            <button type="button" class="quick-btn" data-value="100000000">+100M</button>
                             <button type="button" class="quick-btn" data-value="1000000000">+1B</button>
                         </div>
                         <div class="action-right">

--- a/index.html
+++ b/index.html
@@ -129,8 +129,7 @@
                     >
                     <div class="input-actions">
                         <div class="quick-buttons">
-                            <button type="button" class="quick-btn" data-value="10000000">+10M</button>
-                            <button type="button" class="quick-btn" data-value="100000000">+100M</button>
+                            <button type="button" class="quick-btn" data-value="1000000">+1M</button>
                             <button type="button" class="quick-btn" data-value="1000000000">+1B</button>
                         </div>
                         <div class="action-right">

--- a/script.js
+++ b/script.js
@@ -963,6 +963,7 @@ const confidenceButton = document.getElementById('confidence-button');
 const confidenceMenu = document.getElementById('confidence-menu');
 const confidenceWrapper = document.querySelector('.confidence-wrapper');
 const submitBtn = document.getElementById('submit-btn');
+const quickButtons = document.querySelectorAll('.quick-btn');
 const sendIcon = `\
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
   <path d="M2 21L23 12L2 3v7l12 2L2 14v7z"/>
@@ -2845,6 +2846,16 @@ function setupEventListeners() {
             const formattedValue = formatNumber(number);
             input.value = formattedValue;
         }
+    });
+
+    quickButtons.forEach((btn) => {
+        btn.addEventListener('click', () => {
+            const increment = parseInt(btn.dataset.value, 10);
+            const current = parseInt(guessInput.value.replace(/[^\d]/g, ''), 10) || 0;
+            const newValue = current + increment;
+            guessInput.value = formatNumber(newValue);
+            guessInput.focus();
+        });
     });
 
     // Help button

--- a/script.js
+++ b/script.js
@@ -934,6 +934,15 @@ const fermiQuestions = [
         hint: "St. Peter is recognized as the first pope and died around AD 64.",
         date: "2025-09-14",
         image: "data:image/svg+xml;charset=UTF-8,%3csvg xmlns='http://www.w3.org/2000/svg' width='100' height='100' viewBox='0 0 100 100'%3e%3crect width='100' height='100' fill='%23f8fafc'/%3e%3ctext x='50' y='62' font-size='40' text-anchor='middle' fill='%23374151'%3e️⛪️%3c/text%3e%3c/svg%3e"
+    },
+    {
+        question: "How many visitors does the London Eye observation wheel receive each year?",
+        answer: 3500000,
+        category: "",
+        explanation: "",
+        hint: "The London Eye has 32 capsules, each of which holds up to 25 passengers.",
+        date: "2025-09-15",
+        image: "data:image/svg+xml;charset=UTF-8,%3csvg xmlns='http://www.w3.org/2000/svg' width='100' height='100' viewBox='0 0 100 100'%3e%3crect width='100' height='100' fill='%23f8fafc'/%3e%3ctext x='50' y='62' font-size='40' text-anchor='middle' fill='%23374151'%3e️🎡%3c/text%3e%3c/svg%3e"
     }
 ];
 

--- a/script.js
+++ b/script.js
@@ -2045,6 +2045,10 @@ function updateConfidenceInputVisibility() {
     const firstOnlyActive = firstGuessCheckbox && firstGuessCheckbox.checked;
     const showConfidence = calibrationEnabled && (!firstOnlyActive || currentGuess === 0);
 
+    if (confidenceWrapper) {
+        confidenceWrapper.style.display = showConfidence ? '' : 'none';
+    }
+
     if (confidenceInput && confidenceButton) {
         const prevValue = confidenceInput.value;
         if (showConfidence) {

--- a/script.js
+++ b/script.js
@@ -1722,9 +1722,12 @@ function endGame() {
         newGameBtnInline.onclick = showStats;
     } else {
         newGameBtnInline.textContent = 'Play more';
-        newGameBtnInline.onclick = startNewGame;
-    }    
+        newGameBtnInline.onclick = startNewGame;  
+    }
     updateStreakDisplay(); // Update streak display when game ends
+
+    // Simple scroll to top to ensure good positioning
+    window.scrollTo(0, 0);
 }
 
 // Start a new game

--- a/styles.css
+++ b/styles.css
@@ -599,7 +599,7 @@ button#stats-btn {
     font-family: 'Press Start 2P', monospace;
     outline: none;
     width: 100%;
-    padding: 18.5px 15px 13.5px 15px;
+    padding: 19.5px 15px 14.5px 15px;
     border-radius: 13px 13px 0 0;
 }
 
@@ -608,12 +608,12 @@ button#stats-btn {
 }
 
 #confidence-input {
-    margin: 0 10px 0 0;
+    margin: 0;
     height: 36px;
     width: 71px;
     padding: 0;
     background: none;
-    border: 2px solid #eaecf0;
+    border: 0;
     color: #333;
     font-size: 0.8rem;
     font-family: 'Press Start 2P', monospace;
@@ -629,7 +629,7 @@ button#stats-btn {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    padding: 0 10px 8px 10px;
+    padding: 0 12px 12px 12px;
     gap: 10px;
 }
 
@@ -642,7 +642,7 @@ button#stats-btn {
     background: #e9ecef;
     border: 2px solid #eaecf0;
     border-radius: 10px;
-    padding: 6px 8px;
+    padding: 8px 8px;
     font-family: 'Press Start 2P', monospace;
     font-size: 0.7rem;
     cursor: pointer;
@@ -706,7 +706,7 @@ button#stats-btn {
 }
 
 #confidence-button {
-    margin: 0 10px 0 0;
+    margin: 0;
     height: 36px;
     width: 71px;
     padding: 0;
@@ -725,7 +725,7 @@ button#stats-btn {
 #confidence-button::after {
     content: '>';
     position: absolute;
-    right: 8px;
+    right: 2px;
     top: 50%;
     transform: translateY(-50%) rotate(90deg);
     font-size: 0.6rem;
@@ -780,12 +780,12 @@ button#stats-btn {
 
 .submit-btn {
     width: 110px;
-    height: 36px;
+    height: 40px;
     background-color: #3498db;
     color: white;
     border: none;
     padding: 8px 12px;
-    border-radius: 15px;
+    border-radius: 12px;
     font-family: 'Press Start 2P', monospace;
     font-size: 0.8rem;
     cursor: pointer;
@@ -1231,9 +1231,9 @@ button#stats-btn {
         padding-left: 0;
     }
     #confidence-button {
-        margin: 0 8px 0 0;
+        margin: 0;
         width: 70px;
-        padding-left: 4px;
+        padding-left: 0;
     }
     .comments-section {
         position: fixed;

--- a/styles.css
+++ b/styles.css
@@ -660,6 +660,9 @@ button#stats-btn {
 
 .confidence-wrapper {
     position: relative;
+    border: 2px solid #eaecf0;
+    border-radius: 12px;
+    padding: 0 8px;
 }
 
 .confidence-wrapper::after {
@@ -708,7 +711,7 @@ button#stats-btn {
     width: 71px;
     padding: 0;
     background: none;
-    border: 2px solid #eaecf0;
+    border: 0;
     color: #333;
     font-size: 0.8rem;
     font-family: 'Press Start 2P', monospace;
@@ -798,8 +801,8 @@ button#stats-btn {
 }
 
 .submit-btn svg {
-    width: 24px;
-    height: 24px;
+    width: 20px;
+    height: 20px;
 }
 
 .submit-btn:disabled {
@@ -1223,6 +1226,9 @@ button#stats-btn {
     .source-btn {
         font-size: 0.78rem;
         height: 63px;
+    }
+    .confidence-wrapper {
+        padding-left: 0;
     }
     #confidence-button {
         margin: 0 8px 0 0;

--- a/styles.css
+++ b/styles.css
@@ -643,6 +643,7 @@ button#stats-btn {
     border: 2px solid #eaecf0;
     border-radius: 10px;
     padding: 8px 8px;
+    color: #333;
     font-family: 'Press Start 2P', monospace;
     font-size: 0.7rem;
     cursor: pointer;

--- a/styles.css
+++ b/styles.css
@@ -1131,7 +1131,7 @@ button#stats-btn {
     .game-container {
         padding: 0;
         border-radius: 18px;
-        padding-bottom: 85px; /* space for fixed input/new game area */
+        padding-bottom: 134px; /* space for fixed input/new game area */
         background: transparent;
     }
     .question-container {

--- a/styles.css
+++ b/styles.css
@@ -589,19 +589,17 @@ button#stats-btn {
     border-radius: 15px;
     flex: 1;
     border: 2px solid #eaecf0;
-    overflow: hidden;
 }
 
 #guess-input {
     flex: none;
     background: none;
     border: none;
-    border-bottom: 2px solid #eaecf0;
     font-size: 0.8rem;
     font-family: 'Press Start 2P', monospace;
     outline: none;
     width: 100%;
-    padding: 18.5px 15px;
+    padding: 18.5px 15px 13.5px 15px;
     border-radius: 13px 13px 0 0;
 }
 
@@ -631,7 +629,7 @@ button#stats-btn {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    padding: 8px 10px;
+    padding: 0 10px 8px 10px;
     gap: 10px;
 }
 

--- a/styles.css
+++ b/styles.css
@@ -581,29 +581,28 @@ button#stats-btn {
 .input-row {
     display: flex;
     align-items: center;
-    gap: 10px;
 }
 
 .input-container {
-    height: 54px;
     display: flex;
-    align-items: center;
+    flex-direction: column;
     border-radius: 15px;
     flex: 1;
     border: 2px solid #eaecf0;
+    overflow: hidden;
 }
 
 #guess-input {
-    flex: 1;
+    flex: none;
     background: none;
     border: none;
+    border-bottom: 2px solid #eaecf0;
     font-size: 0.8rem;
     font-family: 'Press Start 2P', monospace;
     outline: none;
-    min-width: 0;
     width: 100%;
-    padding: 18.5px 0px 18.5px 15px;
-    border-radius: 15px;
+    padding: 18.5px 15px;
+    border-radius: 13px 13px 0 0;
 }
 
 #guess-input::placeholder {
@@ -612,22 +611,53 @@ button#stats-btn {
 
 #confidence-input {
     margin: 0 10px 0 0;
-    height: 100%;
+    height: 36px;
     width: 71px;
-    padding: 18.5px 0;
+    padding: 0;
     background: none;
-    padding-right: 0px;
-    -webkit-padding-end: 0px;
-    border: none;
-    border-left: 2px solid #eaecf0;
-    border-radius: 0;
+    border: 2px solid #eaecf0;
     color: #333;
     font-size: 0.8rem;
     font-family: 'Press Start 2P', monospace;
     outline: none;
-    text-align: right;
-    padding-inline-start: 0;
+    text-align: center;
     display: none;
+    border-radius: 10px;
+    -webkit-padding-end: 0px;
+    padding-inline-start: 0;
+}
+
+.input-actions {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 8px 10px;
+    gap: 10px;
+}
+
+.quick-buttons {
+    display: flex;
+    gap: 6px;
+}
+
+.quick-btn {
+    background: #e9ecef;
+    border: 2px solid #eaecf0;
+    border-radius: 10px;
+    padding: 6px 8px;
+    font-family: 'Press Start 2P', monospace;
+    font-size: 0.7rem;
+    cursor: pointer;
+}
+
+.quick-btn:hover {
+    background: #dfe3e6;
+}
+
+.action-right {
+    display: flex;
+    align-items: center;
+    gap: 10px;
 }
 
 .confidence-wrapper {
@@ -676,27 +706,25 @@ button#stats-btn {
 
 #confidence-button {
     margin: 0 10px 0 0;
-    height: 100%;
+    height: 36px;
     width: 71px;
-    padding: 18.5px 0;
+    padding: 0;
     background: none;
-    padding-right: 18px;
-    border: none;
-    border-left: 2px solid #eaecf0;
+    border: 2px solid #eaecf0;
     color: #333;
     font-size: 0.8rem;
     font-family: 'Press Start 2P', monospace;
-    text-align: right;
-    padding-inline-start: 0;
+    text-align: center;
     display: none;
     cursor: pointer;
     position: relative;
+    border-radius: 10px;
 }
 
 #confidence-button::after {
     content: '>';
     position: absolute;
-    right: 4px;
+    right: 8px;
     top: 50%;
     transform: translateY(-50%) rotate(90deg);
     font-size: 0.6rem;
@@ -751,7 +779,7 @@ button#stats-btn {
 
 .submit-btn {
     width: 110px;
-    height: 54px;
+    height: 36px;
     background-color: #3498db;
     color: white;
     border: none;

--- a/styles.css
+++ b/styles.css
@@ -1231,9 +1231,7 @@ button#stats-btn {
         padding-left: 0;
     }
     #confidence-button {
-        margin: 0;
         width: 70px;
-        padding-left: 0;
     }
     .comments-section {
         position: fixed;


### PR DESCRIPTION
## Summary
- embed submit button inside guess input container
- add quick-add buttons for +10M, +100M, +1B guesses
- style and script updates for new input layout

## Testing
- `node --check script.js && echo "Syntax OK"`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c6a249b82c8329be38a3b60f305ab9