### PR TITLE
Reset confidence selection between guesses

### DIFF
--- a/index.html
+++ b/index.html
@@ -135,24 +135,25 @@
                         <div class="action-right">
                             <div class="confidence-wrapper" data-tooltip="How confident are you that your guess is correct?">
                                 <select id="confidence-input">
+                                    <option value="" selected>..%</option>
                                     <option value="10">10%</option>
                                     <option value="20">20%</option>
                                     <option value="30">30%</option>
                                     <option value="40">40%</option>
-                                    <option value="50" selected>50%</option>
+                                    <option value="50">50%</option>
                                     <option value="60">60%</option>
                                     <option value="70">70%</option>
                                     <option value="80">80%</option>
                                     <option value="90">90%</option>
                                     <option value="100">100%</option>
                                 </select>
-                                <button id="confidence-button" type="button" aria-haspopup="listbox" aria-expanded="false">50%</button>
+                                <button id="confidence-button" type="button" aria-haspopup="listbox" aria-expanded="false">..%</button>
                                 <div id="confidence-menu" class="confidence-menu" role="listbox">
                                     <button type="button" data-value="10" role="option">10%</button>
                                     <button type="button" data-value="20" role="option">20%</button>
                                     <button type="button" data-value="30" role="option">30%</button>
                                     <button type="button" data-value="40" role="option">40%</button>
-                                    <button type="button" data-value="50" role="option" class="selected">50%</button>
+                                    <button type="button" data-value="50" role="option">50%</button>
                                     <button type="button" data-value="60" role="option">60%</button>
                                     <button type="button" data-value="70" role="option">70%</button>
                                     <button type="button" data-value="80" role="option">80%</button>

--- a/script.js
+++ b/script.js
@@ -978,6 +978,14 @@ const sendIcon = `\
   <path d="M2 21L23 12L2 3v7l12 2L2 14v7z"/>
 </svg>`;
 const inputSection = document.getElementById('input-section');
+
+function resetConfidenceInput() {
+    if (confidenceInput) confidenceInput.value = '';
+    if (confidenceButton) confidenceButton.textContent = '..%';
+    if (confidenceMenu) {
+        confidenceMenu.querySelectorAll('.selected').forEach(btn => btn.classList.remove('selected'));
+    }
+}
 const newGameSection = document.getElementById('new-game-section');
 const newGameBtnInline = document.getElementById('new-game-btn-inline');
 const gameOverModal = document.getElementById('game-over-modal');
@@ -1157,6 +1165,7 @@ function startNewGame() {
     }
 
     // Reset confidence input for new game
+    resetConfidenceInput();
     updateConfidenceInputVisibility();
 
     // Update URL to reflect the current question (only if not already navigating)
@@ -1379,6 +1388,7 @@ function submitGuess() {
         endGame();
     }
 
+    resetConfidenceInput();
     // Hide confidence input after first guess if needed
     updateConfidenceInputVisibility();
     applySubmitButtonState();
@@ -2059,13 +2069,11 @@ function updateConfidenceInputVisibility() {
     }
 
     if (confidenceInput && confidenceButton) {
-        const prevValue = confidenceInput.value;
         if (showConfidence) {
-            const val = prevValue || '50';
-            confidenceInput.value = val;
-            confidenceButton.textContent = val + '%';
+            const val = confidenceInput.value;
+            confidenceButton.textContent = val ? val + '%' : '..%';
         } else {
-            confidenceInput.value = '';
+            resetConfidenceInput();
             confidenceMenu && confidenceMenu.classList.remove('open');
             confidenceButton.setAttribute('aria-expanded', 'false');
         }


### PR DESCRIPTION
## Summary
- Show `..%` placeholder for confidence selection instead of defaulting to 50%
- Clear confidence selection after each guess and on new games
- Keep button text in sync with current confidence value

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68c83ab045a08329a8783da9d956a488