### PR TITLE
Add stats dropdown to inline new game button

### DIFF
--- a/index.html
+++ b/index.html
@@ -171,7 +171,25 @@
         <!-- New Game Button (hidden by default) -->
         <div class="new-game-section" id="new-game-section" style="display: none;">
             <button id="share-btn" class="share-btn" style="display: none;">Share</button>
-            <button id="new-game-btn-inline" class="new-game-btn-inline">Play more</button>
+            <div id="new-game-inline-wrapper" class="new-game-inline-wrapper">
+                <button id="new-game-btn-inline" class="new-game-btn-inline" type="button">
+                    <span id="new-game-btn-label">Play more</span>
+                </button>
+                <button
+                    id="new-game-dropdown-toggle"
+                    class="new-game-dropdown-toggle"
+                    type="button"
+                    aria-haspopup="true"
+                    aria-expanded="false"
+                    aria-controls="new-game-dropdown-menu"
+                >
+                    <span class="visually-hidden">More options</span>
+                    <span class="dropdown-arrow">&gt;</span>
+                </button>
+                <div id="new-game-dropdown-menu" class="new-game-dropdown-menu" role="menu" aria-hidden="true">
+                    <button type="button" id="new-game-show-stats" role="menuitem">Show stats</button>
+                </div>
+            </div>
         </div>
 
         <!-- Game Over Modal -->

--- a/script.js
+++ b/script.js
@@ -1000,6 +1000,11 @@ function resetConfidenceInput() {
 }
 const newGameSection = document.getElementById('new-game-section');
 const newGameBtnInline = document.getElementById('new-game-btn-inline');
+const newGameDropdownToggle = document.getElementById('new-game-dropdown-toggle');
+const newGameDropdownMenu = document.getElementById('new-game-dropdown-menu');
+const newGameShowStatsBtn = document.getElementById('new-game-show-stats');
+const newGameBtnLabel = document.getElementById('new-game-btn-label');
+let isNewGameDropdownOpen = false;
 const gameOverModal = document.getElementById('game-over-modal');
 const modalTitle = document.getElementById('modal-title');
 const modalMessage = document.getElementById('modal-message');
@@ -1033,6 +1038,72 @@ const commentsList = document.getElementById('comments-list');
 const commentInput = document.getElementById('comment-input');
 const commentSubmitBtn = document.getElementById('comment-submit-btn');
 const commentCountEl = document.getElementById('comment-count');
+
+
+function closeNewGameDropdown() {
+    if (newGameDropdownMenu) {
+        newGameDropdownMenu.classList.remove('open');
+        newGameDropdownMenu.setAttribute('aria-hidden', 'true');
+    }
+    if (newGameDropdownToggle) {
+        newGameDropdownToggle.setAttribute('aria-expanded', 'false');
+    }
+    if (isNewGameDropdownOpen) {
+        document.removeEventListener('pointerdown', handleNewGameDropdownOutsideClick);
+        document.removeEventListener('keydown', handleNewGameDropdownKeydown);
+    }
+    isNewGameDropdownOpen = false;
+}
+
+function openNewGameDropdown() {
+    if (!newGameDropdownMenu) return;
+    newGameDropdownMenu.classList.add('open');
+    newGameDropdownMenu.setAttribute('aria-hidden', 'false');
+    if (newGameDropdownToggle) {
+        newGameDropdownToggle.setAttribute('aria-expanded', 'true');
+    }
+    isNewGameDropdownOpen = true;
+    document.addEventListener('pointerdown', handleNewGameDropdownOutsideClick);
+    document.addEventListener('keydown', handleNewGameDropdownKeydown);
+    if (newGameShowStatsBtn) {
+        newGameShowStatsBtn.focus();
+    }
+}
+
+function handleNewGameDropdownOutsideClick(event) {
+    const target = event.target;
+    if (!newGameDropdownMenu) return;
+    if (newGameDropdownMenu.contains(target) || (newGameDropdownToggle && newGameDropdownToggle.contains(target))) {
+        return;
+    }
+    closeNewGameDropdown();
+}
+
+function handleNewGameDropdownKeydown(event) {
+    if (event.key === 'Escape') {
+        closeNewGameDropdown();
+        if (newGameDropdownToggle) {
+            newGameDropdownToggle.focus();
+        }
+    } else if (event.key === 'Tab') {
+        closeNewGameDropdown();
+    }
+}
+
+function updateNewGameButton(allQuestionsCompleted) {
+    if (!newGameBtnInline) return;
+
+    if (newGameBtnLabel) {
+        newGameBtnLabel.textContent = 'Play more';
+    } else {
+        newGameBtnInline.textContent = 'Play more';
+    }
+
+    newGameBtnInline.onclick = startNewGame;
+    newGameBtnInline.setAttribute('data-all-completed', allQuestionsCompleted ? 'true' : 'false');
+
+    closeNewGameDropdown();
+}
 
 
 // Confidence tooltip
@@ -1123,8 +1194,9 @@ function updateQuestionDisplay(question) {
 
 // Start a new game
 function startNewGame() {
+    closeNewGameDropdown();
     currentQuestion = getCurrentQuestion();
-    
+
     if (!currentQuestion) {
         console.error('No questions available');
         return;
@@ -1756,13 +1828,7 @@ function endGame() {
     shareBtn.style.display = 'block'; // Show share button after game ends
 
     // Update button text and functionality based on completion status
-    if (allCompleted) {
-        newGameBtnInline.textContent = 'Show stats';
-        newGameBtnInline.onclick = showStats;
-    } else {
-        newGameBtnInline.textContent = 'Play more';
-        newGameBtnInline.onclick = startNewGame;  
-    }
+    updateNewGameButton(allCompleted);
     updateStreakDisplay(); // Update streak display when game ends
 
     // Simple scroll to top to ensure good positioning
@@ -1782,6 +1848,7 @@ function showHelp() {
 
 // Show stats modal
 function showStats() {
+    closeNewGameDropdown();
     updateStatsDisplay();
     statsModal.style.display = 'block';
 }
@@ -2453,13 +2520,7 @@ function endGameDisplay() {
     shareBtn.style.display = 'block'; // Show share button after game ends
 
     // Update button text and functionality based on completion status
-    if (allCompleted) {
-        newGameBtnInline.textContent = 'Show stats';
-        newGameBtnInline.onclick = showStats;
-    } else {
-        newGameBtnInline.textContent = 'Play more';
-        newGameBtnInline.onclick = startNewGame;
-    }
+    updateNewGameButton(allCompleted);
 }
 
 // Show questions history modal
@@ -2959,7 +3020,31 @@ function setupEventListeners() {
     
     // Stats button
     statsBtn.addEventListener('click', showStats);
-    
+
+    if (newGameBtnInline) {
+        newGameBtnInline.addEventListener('click', () => {
+            closeNewGameDropdown();
+        });
+    }
+
+    if (newGameDropdownToggle && newGameDropdownMenu) {
+        newGameDropdownToggle.addEventListener('click', (event) => {
+            event.stopPropagation();
+            if (isNewGameDropdownOpen) {
+                closeNewGameDropdown();
+            } else {
+                openNewGameDropdown();
+            }
+        });
+    }
+
+    if (newGameShowStatsBtn) {
+        newGameShowStatsBtn.addEventListener('click', () => {
+            closeNewGameDropdown();
+            showStats();
+        });
+    }
+
     // Strategy tips (mobile link in guess counter)
     if (strategyTipsBtn) {
         strategyTipsBtn.addEventListener('click', showHelp);

--- a/styles.css
+++ b/styles.css
@@ -16,6 +16,18 @@ button {
     touch-action: manipulation;
 }
 
+.visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
 .game-container {
     max-width: 500px;
     margin: 0 auto;
@@ -372,24 +384,113 @@ button#stats-btn {
     margin-top: 20px;
     text-align: center;
     gap: 10px;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    align-items: stretch;
+}
+
+.new-game-inline-wrapper {
+    position: relative;
+    display: flex;
+    width: 100%;
+    flex: 1;
+    min-width: 0;
+    border-radius: 15px;
+    overflow: hidden;
 }
 
 .new-game-btn-inline {
-    width: 100%;
+    flex: 1;
     height: 54px;
     background-color: #3498db;
     color: white;
     border: none;
     padding: 12px 25px;
-    border-radius: 15px;
+    border-radius: 15px 0 0 15px;
     font-family: 'Press Start 2P', monospace;
     font-size: 0.8rem;
     cursor: pointer;
-    transition: background-color 0.2s;
+    transition: background-color 0.2s ease;
+    display: flex;
+    align-items: center;
+    justify-content: center;
 }
 
-.new-game-btn-inline:hover {
+.new-game-dropdown-toggle {
+    height: 54px;
+    padding: 0 18px;
+    background-color: #3498db;
+    color: white;
+    border: none;
+    border-left: 1px solid #ffffff;
+    font-family: 'Press Start 2P', monospace;
+    font-size: 0.8rem;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: background-color 0.2s ease;
+}
+
+.new-game-inline-wrapper:hover .new-game-btn-inline,
+.new-game-inline-wrapper:hover .new-game-dropdown-toggle,
+.new-game-inline-wrapper:focus-within .new-game-btn-inline,
+.new-game-inline-wrapper:focus-within .new-game-dropdown-toggle {
     background-color: #2e86c1;
+}
+
+.new-game-btn-inline:focus-visible,
+.new-game-dropdown-toggle:focus-visible {
+    outline: 2px solid rgba(255, 255, 255, 0.9);
+    outline-offset: -4px;
+}
+
+.dropdown-arrow {
+    display: inline-block;
+    transform: rotate(90deg);
+    transition: transform 0.2s ease;
+}
+
+.new-game-dropdown-toggle[aria-expanded="true"] .dropdown-arrow {
+    transform: rotate(-90deg);
+}
+
+.new-game-dropdown-menu {
+    position: absolute;
+    top: calc(100% + 8px);
+    right: 0;
+    background: #ffffff;
+    border-radius: 12px;
+    border: 1px solid rgba(0, 0, 0, 0.08);
+    box-shadow: 0 18px 30px rgba(15, 23, 42, 0.16);
+    padding: 8px 0;
+    min-width: 160px;
+    display: none;
+    z-index: 25;
+}
+
+.new-game-dropdown-menu.open {
+    display: block;
+}
+
+.new-game-dropdown-menu button {
+    width: 100%;
+    padding: 10px 16px;
+    background: none;
+    border: none;
+    color: #333;
+    text-align: left;
+    font-family: 'Press Start 2P', monospace;
+    font-size: 0.7rem;
+    cursor: pointer;
+    transition: background-color 0.2s ease;
+}
+
+.new-game-dropdown-menu button:hover,
+.new-game-dropdown-menu button:focus-visible {
+    background-color: #f0f4f8;
+    outline: none;
 }
 
 /* Share Button */
@@ -415,6 +516,7 @@ button#stats-btn {
     margin-top: 0;
     border-radius: 15px;
     border: 2px solid #eaecef;
+    flex-shrink: 0;
 }
 
 /* Guesses Container */


### PR DESCRIPTION
## Summary
- split the inline "Play more" button into a main action and a dropdown toggle with an arrow indicator
- style the new button group and dropdown menu, including accessibility helpers
- wire up JavaScript to manage the dropdown, keep the button label stable, and show the stats modal via the new menu option

## Testing
- Not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68c9280a31f08329bdad161715c08b70