### PR TITLE
Add welcome flow and calendar navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,6 +22,8 @@
                 </h1>
             </div>
             <div class="header-right">
+                <button class="nav-button" id="home-btn">Home</button>
+                <button class="nav-button" id="calendar-btn">Calendar</button>
                 <button class="icon-button" id="help-btn">?</button>
                 <button class="icon-button" id="stats-btn">
                     <svg width="20" height="18" viewBox="0 0 58 51" fill="none" xmlns="http://www.w3.org/2000/svg" shape-rendering="crispEdges">
@@ -32,7 +34,33 @@
                 </button>
             </div>
         </header>
-    <div class="game-container">
+    <main>
+        <section id="welcome-screen" class="view active">
+            <div class="welcome-content">
+                <h2 class="welcome-title">Welcome to Fermi Questions</h2>
+                <p class="welcome-subtitle">Sharpen your estimation skills with a fresh puzzle every day.</p>
+                <div class="daily-challenge-card">
+                    <div class="daily-challenge-header">
+                        <h3>Daily Challenge</h3>
+                        <span id="daily-challenge-date" class="daily-challenge-date"></span>
+                    </div>
+                    <div class="daily-challenge-body">
+                        <div class="daily-challenge-image" id="daily-challenge-image-container" style="display: none;">
+                            <img id="daily-challenge-image" alt="" />
+                        </div>
+                        <div class="daily-challenge-text">
+                            <p id="daily-challenge-question" class="daily-challenge-question"></p>
+                            <p id="daily-challenge-status" class="daily-challenge-status"></p>
+                        </div>
+                    </div>
+                    <button id="play-daily-btn" class="primary-action">Play</button>
+                </div>
+                <button id="calendar-link-btn" class="secondary-action">Browse the calendar</button>
+            </div>
+        </section>
+
+        <section id="game-view" class="view">
+            <div class="game-container">
         <!-- Question Display -->
         <div class="question-container">
             <div class="question-box">
@@ -402,8 +430,23 @@
                 <button id="close-stats-btn" class="close-btn">Close</button>
             </div>
         </div>
-    </div>
+            </div>
+        </section>
+
+        <section id="calendar-view" class="view">
+            <div class="calendar-wrapper">
+                <h2 class="calendar-title">Question Calendar</h2>
+                <p class="calendar-subtitle">Pick a day to play or review its challenge.</p>
+                <div class="calendar-legend">
+                    <span><span class="legend-box pending"></span> Not played</span>
+                    <span><span class="legend-box won"></span> Completed</span>
+                    <span><span class="legend-box lost"></span> Missed</span>
+                </div>
+                <div id="calendar-months" class="calendar-months"></div>
+            </div>
+        </section>
+    </main>
 
     <script src="script.js"></script>
 </body>
-</html> 
+</html>

--- a/index.html
+++ b/index.html
@@ -22,8 +22,6 @@
                 </h1>
             </div>
             <div class="header-right">
-                <button class="nav-button" id="home-btn">Home</button>
-                <button class="nav-button" id="calendar-btn">Calendar</button>
                 <button class="icon-button" id="help-btn">?</button>
                 <button class="icon-button" id="stats-btn">
                     <svg width="20" height="18" viewBox="0 0 58 51" fill="none" xmlns="http://www.w3.org/2000/svg" shape-rendering="crispEdges">
@@ -446,6 +444,11 @@
             </div>
         </section>
     </main>
+
+    <nav class="mobile-nav" aria-label="Primary">
+        <button type="button" class="nav-button" id="home-btn">Home</button>
+        <button type="button" class="nav-button" id="calendar-btn">Calendar</button>
+    </nav>
 
     <script src="script.js"></script>
 </body>

--- a/script.js
+++ b/script.js
@@ -438,6 +438,8 @@ let completedQuestions = {}; // Changed from array to object to track win/loss s
 
 // URL Routing state
 let isNavigating = false;
+let currentView = 'welcome';
+let todaysQuestion = null;
 
 // Statistics
 let stats = {
@@ -977,6 +979,19 @@ const fermiQuestions = [
 ];
 
 // DOM elements
+const welcomeScreen = document.getElementById('welcome-screen');
+const gameView = document.getElementById('game-view');
+const calendarView = document.getElementById('calendar-view');
+const playDailyBtn = document.getElementById('play-daily-btn');
+const calendarLinkBtn = document.getElementById('calendar-link-btn');
+const homeBtn = document.getElementById('home-btn');
+const calendarBtn = document.getElementById('calendar-btn');
+const dailyChallengeQuestionEl = document.getElementById('daily-challenge-question');
+const dailyChallengeDateEl = document.getElementById('daily-challenge-date');
+const dailyChallengeStatusEl = document.getElementById('daily-challenge-status');
+const dailyChallengeImageContainer = document.getElementById('daily-challenge-image-container');
+const dailyChallengeImageEl = document.getElementById('daily-challenge-image');
+const calendarMonthsContainer = document.getElementById('calendar-months');
 const questionText = document.getElementById('question-text');
 const questionCategory = document.getElementById('question-category');
 const questionImage = document.getElementById('question-image');
@@ -1080,25 +1095,39 @@ function initGame() {
     loadCalibrationSetting();
     initConfidenceTooltip();
 
-    // If URL has a specific question date, navigate to it first
-    let navigatedFromURL = false;
-    const initialRouteDate = parseURL();
-    if (initialRouteDate) {
-        navigatedFromURL = navigateToQuestion(initialRouteDate);
+    const initialRoute = parseURL();
+    let navigatedFromRoute = false;
+
+    if (initialRoute.view === 'game' && initialRoute.date) {
+        navigatedFromRoute = navigateToQuestion(initialRoute.date);
     }
 
-    // If no route navigation occurred, try restoring saved state; else start new
-    let restoredFromSave = false;
-    if (!navigatedFromURL) {
-        restoredFromSave = loadCurrentGameState();
+    if (!navigatedFromRoute) {
+        const restoredFromSave = loadCurrentGameState();
         if (!restoredFromSave) {
-            startNewGame();
+            startNewGame(true);
         }
+    }
+
+    refreshDailyChallengeSummary();
+    renderCalendar();
+
+    if (navigatedFromRoute) {
+        setActiveView('game', { skipURLUpdate: true, force: true });
+    } else if (initialRoute.view === 'calendar') {
+        setActiveView('calendar', { skipURLUpdate: true, force: true });
+    } else if (initialRoute.view === 'game' && initialRoute.date) {
+        setActiveView('game', { skipURLUpdate: true, force: true });
+        if (currentQuestion) {
+            updateURL(currentQuestion.date);
+        }
+    } else {
+        setActiveView('welcome', { force: true });
     }
 
     setupEventListeners();
     // Always initialize routing; allow it to handle future navigations
-    initRouting(false);
+    initRouting(true);
 }
 
 // Update question display including image
@@ -1134,9 +1163,9 @@ function updateQuestionDisplay(question) {
 }
 
 // Start a new game
-function startNewGame() {
+function startNewGame(skipURLUpdate = false) {
     currentQuestion = getCurrentQuestion();
-    
+
     if (!currentQuestion) {
         console.error('No questions available');
         return;
@@ -1192,9 +1221,12 @@ function startNewGame() {
     updateConfidenceInputVisibility();
 
     // Update URL to reflect the current question (only if not already navigating)
-    if (!isNavigating) {
+    if (!isNavigating && !skipURLUpdate && currentView === 'game') {
         updateURL(currentQuestion.date);
     }
+
+    refreshDailyChallengeSummary();
+    renderCalendar();
 }
 
 // Get current date in YYYY-MM-DD format
@@ -1241,13 +1273,270 @@ function getCurrentQuestion() {
 // Get question display text
 function getQuestionDisplayText(question) {
     const today = getCurrentDate();
-    
+
     if (question.date === today) {
         return "Question of the Day";
     } else {
         const formattedDate = formatDateForDisplay(question.date);
         return `${formattedDate} <span class='arrow'>></span>`;
     }
+}
+
+function getTodaysQuestion() {
+    return getQuestionForDate(getCurrentDate());
+}
+
+function refreshDailyChallengeSummary() {
+    if (!dailyChallengeQuestionEl || !dailyChallengeDateEl) return;
+
+    const todayQuestion = getTodaysQuestion();
+    todaysQuestion = todayQuestion || null;
+
+    if (!todayQuestion) {
+        dailyChallengeQuestionEl.textContent = 'No daily challenge is available right now.';
+        dailyChallengeDateEl.textContent = '';
+        if (dailyChallengeStatusEl) {
+            dailyChallengeStatusEl.textContent = '';
+            dailyChallengeStatusEl.classList.remove('status-won', 'status-lost');
+        }
+        if (dailyChallengeImageContainer) {
+            dailyChallengeImageContainer.style.display = 'none';
+        }
+        if (playDailyBtn) {
+            playDailyBtn.disabled = true;
+            playDailyBtn.textContent = 'Unavailable';
+        }
+        return;
+    }
+
+    const todayDate = getCurrentDate();
+    const formattedDate = todayQuestion.date === todayDate
+        ? 'Today'
+        : formatDateForDisplay(todayQuestion.date);
+
+    dailyChallengeDateEl.textContent = formattedDate;
+    dailyChallengeQuestionEl.textContent = todayQuestion.question;
+
+    if (dailyChallengeImageContainer) {
+        if (todayQuestion.image) {
+            dailyChallengeImageContainer.style.display = 'flex';
+            if (dailyChallengeImageEl) {
+                dailyChallengeImageEl.src = todayQuestion.image;
+                dailyChallengeImageEl.alt = `Image for ${todayQuestion.question}`;
+            }
+        } else {
+            dailyChallengeImageContainer.style.display = 'none';
+        }
+    }
+
+    if (playDailyBtn) {
+        playDailyBtn.disabled = false;
+    }
+
+    if (dailyChallengeStatusEl) {
+        dailyChallengeStatusEl.classList.remove('status-won', 'status-lost');
+    }
+
+    const completed = completedQuestions[todayQuestion.date];
+    if (completed) {
+        if (dailyChallengeStatusEl) {
+            dailyChallengeStatusEl.textContent = completed.won ? 'Completed · ✔' : 'Completed · ✘';
+            dailyChallengeStatusEl.classList.add(completed.won ? 'status-won' : 'status-lost');
+        }
+        if (playDailyBtn) {
+            playDailyBtn.textContent = 'Review';
+        }
+    } else {
+        if (dailyChallengeStatusEl) {
+            dailyChallengeStatusEl.textContent = 'Ready to play';
+        }
+        if (playDailyBtn) {
+            playDailyBtn.textContent = 'Play';
+        }
+    }
+}
+
+function updateHash(newHash) {
+    if (window.location.hash !== newHash) {
+        window.history.pushState(null, '', newHash);
+    }
+}
+
+function setActiveView(view, options = {}) {
+    const { skipURLUpdate = false, force = false } = options;
+    if (!force && currentView === view) {
+        if (view === 'calendar') {
+            renderCalendar();
+        } else if (view === 'welcome') {
+            refreshDailyChallengeSummary();
+        }
+        return;
+    }
+
+    currentView = view;
+
+    if (welcomeScreen) {
+        welcomeScreen.classList.toggle('active', view === 'welcome');
+    }
+    if (gameView) {
+        gameView.classList.toggle('active', view === 'game');
+    }
+    if (calendarView) {
+        calendarView.classList.toggle('active', view === 'calendar');
+    }
+
+    if (!skipURLUpdate) {
+        if (view === 'welcome') {
+            updateHash('#/welcome');
+        } else if (view === 'calendar') {
+            updateHash('#/calendar');
+        }
+    }
+
+    if (view === 'calendar') {
+        renderCalendar();
+    } else if (view === 'welcome') {
+        refreshDailyChallengeSummary();
+    } else if (view === 'game') {
+        if (guessInput && !('ontouchstart' in window) && !navigator.maxTouchPoints) {
+            setTimeout(() => guessInput.focus(), 150);
+        }
+    }
+}
+
+function renderCalendar() {
+    if (!calendarMonthsContainer) return;
+
+    const today = getCurrentDate();
+    const activeQuestionDate = currentQuestion ? currentQuestion.date : null;
+    const sortedQuestions = [...fermiQuestions].sort((a, b) => a.date.localeCompare(b.date));
+
+    if (sortedQuestions.length === 0) {
+        calendarMonthsContainer.innerHTML = '<p class="calendar-note">No questions available yet.</p>';
+        return;
+    }
+
+    const questionsByMonth = new Map();
+    sortedQuestions.forEach((question) => {
+        const monthKey = question.date.slice(0, 7);
+        if (!questionsByMonth.has(monthKey)) {
+            questionsByMonth.set(monthKey, []);
+        }
+        questionsByMonth.get(monthKey).push(question);
+    });
+
+    calendarMonthsContainer.innerHTML = '';
+    const dayLabels = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+
+    questionsByMonth.forEach((monthQuestions, monthKey) => {
+        const monthContainer = document.createElement('div');
+        monthContainer.className = 'calendar-month';
+
+        const monthHeader = document.createElement('h3');
+        const monthDate = new Date(`${monthKey}-01T00:00:00`);
+        monthHeader.textContent = monthDate.toLocaleDateString('en-GB', { month: 'long', year: 'numeric' });
+        monthContainer.appendChild(monthHeader);
+
+        const grid = document.createElement('div');
+        grid.className = 'calendar-grid';
+
+        dayLabels.forEach((label) => {
+            const labelCell = document.createElement('div');
+            labelCell.className = 'calendar-day-label';
+            labelCell.textContent = label;
+            grid.appendChild(labelCell);
+        });
+
+        const questionByDay = new Map();
+        monthQuestions.forEach((question) => {
+            const dayNumber = parseInt(question.date.slice(8, 10), 10);
+            questionByDay.set(dayNumber, question);
+        });
+
+        const firstDayIndex = monthDate.getDay();
+        for (let i = 0; i < firstDayIndex; i++) {
+            const emptyCell = document.createElement('div');
+            emptyCell.className = 'calendar-cell empty';
+            grid.appendChild(emptyCell);
+        }
+
+        const daysInMonth = new Date(monthDate.getFullYear(), monthDate.getMonth() + 1, 0).getDate();
+        for (let day = 1; day <= daysInMonth; day++) {
+            const questionForDay = questionByDay.get(day);
+            if (!questionForDay) {
+                const emptyCell = document.createElement('div');
+                emptyCell.className = 'calendar-cell empty';
+                grid.appendChild(emptyCell);
+                continue;
+            }
+
+            const cell = document.createElement('button');
+            cell.type = 'button';
+            cell.className = 'calendar-cell';
+            cell.dataset.date = questionForDay.date;
+
+            const isFuture = questionForDay.date > today;
+            const completed = completedQuestions[questionForDay.date];
+            const isActive = activeQuestionDate === questionForDay.date;
+
+            let labelText = String(day);
+            if (completed) {
+                const won = !!completed.won;
+                labelText = won ? '✔' : '✘';
+                cell.classList.add(won ? 'won' : 'lost');
+            } else if (isFuture) {
+                cell.classList.add('future');
+            } else if (questionForDay.date === today) {
+                cell.classList.add('today');
+            }
+
+            if (isActive) {
+                cell.classList.add('active');
+                cell.setAttribute('aria-current', 'date');
+            } else {
+                cell.removeAttribute('aria-current');
+            }
+
+            cell.textContent = labelText;
+
+            const accessibleParts = [formatDateForDisplay(questionForDay.date)];
+            if (completed) {
+                accessibleParts.push(completed.won ? 'completed successfully' : 'completed without success');
+            } else if (isFuture) {
+                accessibleParts.push('unavailable');
+            } else {
+                accessibleParts.push('available');
+            }
+            if (isActive) {
+                accessibleParts.push('currently selected');
+            }
+            cell.setAttribute('aria-label', accessibleParts.join(', '));
+
+            let titleText = accessibleParts[0];
+            if (completed && typeof completed.guesses === 'number') {
+                const statusText = completed.won ? 'Won' : 'Lost';
+                titleText += ` · ${statusText}`;
+                if (completed.won) {
+                    titleText += ` in ${completed.guesses}/6`;
+                }
+            }
+            cell.title = titleText;
+
+            if (isFuture) {
+                cell.disabled = true;
+            } else {
+                cell.disabled = false;
+                cell.addEventListener('click', () => {
+                    navigateToQuestion(questionForDay.date);
+                });
+            }
+
+            grid.appendChild(cell);
+        }
+
+        monthContainer.appendChild(grid);
+        calendarMonthsContainer.appendChild(monthContainer);
+    });
 }
 
 // Clear previous guesses
@@ -2104,6 +2393,8 @@ function loadStats() {
 // Save completed questions to localStorage
 function saveCompletedQuestions() {
     localStorage.setItem('fermiCompletedQuestions', JSON.stringify(completedQuestions));
+    renderCalendar();
+    refreshDailyChallengeSummary();
 }
 
 // Load completed questions from localStorage
@@ -2295,34 +2586,34 @@ function loadCurrentGameState() {
             // Clear guesses container and restore saved guesses
             clearGuesses();
             restoreGuessesDisplay(gameState.guesses);
-            
-                    // Update game state display
-        if (gameOver) {
-            endGameDisplay(); // Call display updates without stats/completion logic
-        } else {
-            // Show input section for continuing the game
-            guessCounter.style.display = 'block';
-            gameResult.style.display = 'none';
-            inputSection.style.display = 'block';
-            newGameSection.style.display = 'none';
-            shareBtn.style.display = 'none';
-            
-            // Check if hint should be shown (2+ guesses and not won)
-            if (currentGuess >= 2 && !gameWon && currentQuestion.hint) {
-                showHint();
+
+            // Update game state display
+            if (gameOver) {
+                endGameDisplay(); // Call display updates without stats/completion logic
             } else {
-                hideHint();
+                // Show input section for continuing the game
+                guessCounter.style.display = 'block';
+                gameResult.style.display = 'none';
+                inputSection.style.display = 'block';
+                newGameSection.style.display = 'none';
+                shareBtn.style.display = 'none';
+
+                // Check if hint should be shown (2+ guesses and not won)
+                if (currentGuess >= 2 && !gameWon && currentQuestion.hint) {
+                    showHint();
+                } else {
+                    hideHint();
+                }
+
+                // Enable input
+                guessInput.disabled = false;
+                submitBtn.disabled = false;
+
+                // Auto-focus on desktop only
+                if (!('ontouchstart' in window) && !navigator.maxTouchPoints) {
+                    setTimeout(() => guessInput.focus(), 100);
+                }
             }
-            
-            // Enable input
-            guessInput.disabled = false;
-            submitBtn.disabled = false;
-            
-            // Auto-focus on desktop only
-            if (!('ontouchstart' in window) && !navigator.maxTouchPoints) {
-                setTimeout(() => guessInput.focus(), 100);
-            }
-        }
 
             // Ensure confidence input visibility matches current state
             updateConfidenceInputVisibility();
@@ -2361,7 +2652,7 @@ function restoreGuessesDisplay(savedGuesses) {
             guessField.classList.remove('empty');
             
             // Restore feedback
-                if (guess.feedbackType !== 'none') {
+            if (guess.feedbackType !== 'none') {
                 if (guess.feedbackType === 'correct') {
                     // Use the same checkmark SVG from showFeedback function
                     feedbackButton.innerHTML = `
@@ -2389,32 +2680,38 @@ function restoreGuessesDisplay(savedGuesses) {
                 } else {
                     feedbackButton.textContent = guess.feedbackSymbol;
                 }
-                
-                    feedbackButton.className = `feedback-button ${guess.feedbackType}`;
 
-                    // Set tooltip titles for low/high feedback
-                    if (guess.feedbackType === 'low') {
-                        feedbackButton.setAttribute('data-tooltip', 'Too low! You need to go higher ↑');
-                        feedbackButton.title = '';
-                    } else if (guess.feedbackType === 'high') {
-                        feedbackButton.setAttribute('data-tooltip', 'Too high! You need to go lower ↓');
-                        feedbackButton.title = '';
-                    } else if (guess.feedbackType === 'close') {
-                        if (guess.feedbackSymbol === '↑') {
-                            feedbackButton.setAttribute('data-tooltip', 'Too low, but within ±50% of the correct answer!');
-                        } else if (guess.feedbackSymbol === '↓') {
-                            feedbackButton.setAttribute('data-tooltip', 'Too high, but within ±50% of the correct answer!');
-                        } else {
-                            feedbackButton.removeAttribute('data-tooltip');
-                        }
-                        feedbackButton.title = '';
-                    } else if (guess.feedbackType === 'correct') {
-                        feedbackButton.setAttribute('data-tooltip', "You're within ±20% of the correct answer!");
-                        feedbackButton.title = '';
+                feedbackButton.className = `feedback-button ${guess.feedbackType}`;
+
+                // Set tooltip titles for low/high feedback
+                if (guess.feedbackType === 'low') {
+                    feedbackButton.setAttribute('data-tooltip', 'Too low! You need to go higher ↑');
+                    feedbackButton.title = '';
+                } else if (guess.feedbackType === 'high') {
+                    feedbackButton.setAttribute('data-tooltip', 'Too high! You need to go lower ↓');
+                    feedbackButton.title = '';
+                } else if (guess.feedbackType === 'close') {
+                    if (guess.feedbackSymbol === '↑') {
+                        feedbackButton.setAttribute('data-tooltip', 'Too low, but within ±50% of the correct answer!');
+                    } else if (guess.feedbackSymbol === '↓') {
+                        feedbackButton.setAttribute('data-tooltip', 'Too high, but within ±50% of the correct answer!');
                     } else {
                         feedbackButton.removeAttribute('data-tooltip');
-                        feedbackButton.title = '';
                     }
+                    feedbackButton.title = '';
+                } else if (guess.feedbackType === 'correct') {
+                    feedbackButton.setAttribute('data-tooltip', "You're within ±20% of the correct answer!");
+                    feedbackButton.title = '';
+                } else {
+                    feedbackButton.removeAttribute('data-tooltip');
+                    feedbackButton.title = '';
+                }
+            } else {
+                feedbackButton.className = 'feedback-button';
+                feedbackButton.innerHTML = '';
+                feedbackButton.textContent = '';
+                feedbackButton.removeAttribute('data-tooltip');
+                feedbackButton.title = '';
             }
         }
     });
@@ -2677,10 +2974,13 @@ function selectQuestion(question) {
     window.scrollTo(0, 0);
 
     // Update URL without triggering navigation
-    if (!isNavigating) {
+    if (!isNavigating && currentView === 'game') {
         updateURL(question.date);
     }
-    
+
+    refreshDailyChallengeSummary();
+    renderCalendar();
+
     function startFreshQuestion() {
         // Reset game state for new question
         currentGuess = 0;
@@ -2702,16 +3002,16 @@ function selectQuestion(question) {
         
         // Reset input
         guessInput.value = '';
-       guessInput.disabled = false;
-       submitBtn.disabled = false;
+        guessInput.disabled = false;
+        submitBtn.disabled = false;
 
-       // Clear guesses
-       clearGuesses();
+        // Clear guesses
+        clearGuesses();
 
-       // Auto-focus on desktop only
-       if (!('ontouchstart' in window) && !navigator.maxTouchPoints) {
-           guessInput.focus();
-       }
+        // Auto-focus on desktop only
+        if (!('ontouchstart' in window) && !navigator.maxTouchPoints) {
+            guessInput.focus();
+        }
 
         // Show confidence input for first guess only
         updateConfidenceInputVisibility();
@@ -2842,6 +3142,7 @@ function shareStats() {
 
 // Update the URL to reflect the current question
 function updateURL(questionDate) {
+    if (currentView !== 'game') return;
     const newURL = `#/${questionDate}`;
     if (window.location.hash !== newURL) {
         window.history.pushState(null, '', newURL);
@@ -2850,22 +3151,28 @@ function updateURL(questionDate) {
 
 // Parse the current URL and return the question date
 function parseURL() {
-    const hash = window.location.hash;
-    
-    // Check if URL matches pattern #/question/YYYY-MM-DD
+    const hash = window.location.hash || '';
+
+    if (hash === '#/calendar') {
+        return { view: 'calendar' };
+    }
+
     const questionMatch = hash.match(/^#\/(\d{4}-\d{2}-\d{2})$/);
     if (questionMatch) {
-        return questionMatch[1];
+        return { view: 'game', date: questionMatch[1] };
     }
-    
-    // Default to current date if no valid route
-    return null;
+
+    if (hash === '#/welcome' || hash === '#/' || hash === '#') {
+        return { view: 'welcome' };
+    }
+
+    return { view: 'welcome' };
 }
 
 // Navigate to a specific question by date
 function navigateToQuestion(questionDate) {
     const question = getQuestionForDate(questionDate);
-    
+
     if (question) {
         // Check if the question is available (not future-dated)
         const today = getCurrentDate();
@@ -2873,10 +3180,14 @@ function navigateToQuestion(questionDate) {
             isNavigating = true;
             selectQuestion(question);
             isNavigating = false;
+            setActiveView('game', { skipURLUpdate: true, force: true });
+            if (currentQuestion) {
+                updateURL(currentQuestion.date);
+            }
             return true;
         }
     }
-    
+
     // If question not found or not available, redirect to current question
     navigateToCurrentQuestion();
     return false;
@@ -2889,41 +3200,54 @@ function navigateToCurrentQuestion() {
         isNavigating = true;
         selectQuestion(defaultQuestion);
         isNavigating = false;
+        setActiveView('game', { skipURLUpdate: true, force: true });
+        if (currentQuestion) {
+            updateURL(currentQuestion.date);
+        }
+    } else {
+        setActiveView('welcome', { force: true });
     }
 }
 
 // Handle browser back/forward navigation
 function handlePopState() {
-    const questionDate = parseURL();
-    
-    if (questionDate) {
-        navigateToQuestion(questionDate);
-    } else {
-        navigateToCurrentQuestion();
+    const route = parseURL();
+
+    if (route.view === 'calendar') {
+        setActiveView('calendar', { skipURLUpdate: true, force: true });
+        return;
     }
+
+    if (route.view === 'game' && route.date) {
+        if (!navigateToQuestion(route.date)) {
+            navigateToCurrentQuestion();
+        }
+        return;
+    }
+
+    setActiveView('welcome', { skipURLUpdate: true, force: true });
 }
 
 // Initialize routing
 function initRouting(skipInitialNavigation = false) {
     // Handle browser navigation
     window.addEventListener('popstate', handlePopState);
-    
+
     // Skip initial navigation if we restored from saved state
     if (skipInitialNavigation) {
         return;
     }
-    
+
     // Handle initial page load
-    const questionDate = parseURL();
-    if (questionDate) {
-        // Try to navigate to the question from URL
-        if (!navigateToQuestion(questionDate)) {
-            // If navigation failed, update URL to reflect actual question
-            updateURL(currentQuestion.date);
+    const route = parseURL();
+    if (route.view === 'calendar') {
+        setActiveView('calendar', { skipURLUpdate: true, force: true });
+    } else if (route.view === 'game' && route.date) {
+        if (!navigateToQuestion(route.date)) {
+            navigateToCurrentQuestion();
         }
     } else {
-        // No specific question in URL, update URL to show current question
-        updateURL(currentQuestion.date);
+        setActiveView('welcome', { force: true });
     }
 }
 
@@ -2963,9 +3287,38 @@ function setupEventListeners() {
         });
     });
 
+    if (playDailyBtn) {
+        playDailyBtn.addEventListener('click', () => {
+            const todayQuestion = todaysQuestion || getTodaysQuestion();
+            if (todayQuestion) {
+                navigateToQuestion(todayQuestion.date);
+            } else {
+                navigateToCurrentQuestion();
+            }
+        });
+    }
+
+    if (calendarLinkBtn) {
+        calendarLinkBtn.addEventListener('click', () => {
+            setActiveView('calendar');
+        });
+    }
+
+    if (homeBtn) {
+        homeBtn.addEventListener('click', () => {
+            setActiveView('welcome');
+        });
+    }
+
+    if (calendarBtn) {
+        calendarBtn.addEventListener('click', () => {
+            setActiveView('calendar');
+        });
+    }
+
     // Help button
     helpBtn.addEventListener('click', showHelp);
-    
+
     // Stats button
     statsBtn.addEventListener('click', showStats);
     

--- a/styles.css
+++ b/styles.css
@@ -70,6 +70,10 @@ main {
     gap: 10px;
 }
 
+.mobile-nav {
+    display: none;
+}
+
 .nav-button {
     background: #fff;
     font-family: 'Press Start 2P', monospace;
@@ -1652,6 +1656,30 @@ button.calendar-cell:disabled {
         bottom: 0;
         border-radius: 18px 18px 0 0;
         box-shadow: 0 -2px 10px rgba(0,0,0,0.1);
+    }
+
+    main {
+        padding-bottom: 120px;
+    }
+
+    .mobile-nav {
+        display: flex;
+        position: fixed;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        gap: 12px;
+        padding: 12px 20px calc(12px + env(safe-area-inset-bottom));
+        background: rgba(255, 255, 255, 0.96);
+        border-top: 1px solid #e9ecef;
+        box-shadow: 0 -4px 18px rgba(15, 23, 42, 0.08);
+        z-index: 100;
+    }
+
+    .mobile-nav .nav-button {
+        flex: 1;
+        font-size: 0.58rem;
+        padding: 14px 12px;
     }
 }
 

--- a/styles.css
+++ b/styles.css
@@ -20,6 +20,20 @@ button {
     touch-action: manipulation;
 }
 
+main {
+    max-width: 960px;
+    margin: 0 auto 64px;
+    width: 100%;
+}
+
+.view {
+    display: none;
+}
+
+.view.active {
+    display: block;
+}
+
 .game-container {
     max-width: 500px;
     margin: 0 auto;
@@ -54,6 +68,30 @@ button {
     display: flex;
     align-items: center;
     gap: 10px;
+}
+
+.nav-button {
+    background: #fff;
+    font-family: 'Press Start 2P', monospace;
+    font-size: 0.6rem;
+    color: #0f172a;
+    border: 2px solid #e9ecef;
+    border-radius: 12px;
+    padding: 10px 12px;
+    cursor: pointer;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    transition: background-color 0.2s, border-color 0.2s;
+}
+
+.nav-button:hover {
+    background-color: rgba(15, 23, 42, 0.08);
+    border-color: #d4d8dd;
+}
+
+.nav-button:focus-visible {
+    outline: 2px solid #0f172a;
+    outline-offset: 2px;
 }
 
 .game-title {
@@ -1131,6 +1169,396 @@ button#stats-btn {
     padding: 18.5px 15px;
     outline: none;
     line-height: 1.4;
+}
+
+.welcome-content {
+    max-width: 520px;
+    margin: 40px auto;
+    background: rgba(255, 255, 255, 0.95);
+    border: 2px solid #e9ecef;
+    border-radius: 22px;
+    padding: 32px 28px;
+    text-align: center;
+    display: flex;
+    flex-direction: column;
+    gap: 26px;
+    box-shadow: 0 18px 35px rgba(15, 23, 42, 0.08);
+}
+
+.welcome-title {
+    font-size: 1rem;
+}
+
+.welcome-subtitle {
+    font-size: 0.75rem;
+    line-height: 1.6;
+    color: #4b5563;
+}
+
+.daily-challenge-card {
+    border: 2px solid #e9ecef;
+    border-radius: 18px;
+    padding: 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+    background: #fff;
+    text-align: left;
+}
+
+.daily-challenge-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+}
+
+.daily-challenge-header h3 {
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+}
+
+.daily-challenge-date {
+    font-size: 0.65rem;
+    color: #64748b;
+    text-transform: uppercase;
+}
+
+.daily-challenge-body {
+    display: flex;
+    gap: 18px;
+    align-items: center;
+}
+
+.daily-challenge-image {
+    width: 76px;
+    height: 76px;
+    border-radius: 14px;
+    border: 2px solid #e9ecef;
+    background: #f8fafc;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+}
+
+.daily-challenge-image img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.daily-challenge-question {
+    font-size: 0.82rem;
+    line-height: 1.6;
+    color: #0f172a;
+}
+
+.daily-challenge-status {
+    font-size: 0.65rem;
+    color: #475569;
+    margin-top: 6px;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+}
+
+.daily-challenge-status.status-won {
+    color: #15803d;
+}
+
+.daily-challenge-status.status-lost {
+    color: #b91c1c;
+}
+
+.primary-action,
+.secondary-action {
+    font-family: 'Press Start 2P', monospace;
+    border-radius: 14px;
+    cursor: pointer;
+    transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.primary-action {
+    background: #0f172a;
+    color: #fff;
+    padding: 16px 18px;
+    border: none;
+    font-size: 0.72rem;
+    box-shadow: 0 10px 18px rgba(15, 23, 42, 0.18);
+}
+
+.primary-action:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 14px 24px rgba(15, 23, 42, 0.2);
+}
+
+.primary-action:active {
+    transform: translateY(0);
+    box-shadow: 0 6px 12px rgba(15, 23, 42, 0.15);
+}
+
+.secondary-action {
+    background: transparent;
+    border: 2px solid #0f172a;
+    color: #0f172a;
+    padding: 14px 16px;
+    font-size: 0.62rem;
+}
+
+.secondary-action:hover {
+    background: rgba(15, 23, 42, 0.08);
+}
+
+.calendar-wrapper {
+    max-width: 900px;
+    margin: 40px auto;
+    background: rgba(255, 255, 255, 0.97);
+    border: 2px solid #e9ecef;
+    border-radius: 22px;
+    padding: 28px 32px 36px;
+    box-shadow: 0 18px 35px rgba(15, 23, 42, 0.08);
+}
+
+.calendar-title {
+    font-size: 0.95rem;
+    text-align: center;
+    margin-bottom: 10px;
+}
+
+.calendar-subtitle {
+    font-size: 0.72rem;
+    text-align: center;
+    color: #4b5563;
+    margin-bottom: 24px;
+}
+
+.calendar-legend {
+    display: flex;
+    justify-content: center;
+    gap: 18px;
+    flex-wrap: wrap;
+    font-size: 0.58rem;
+    color: #475569;
+    margin-bottom: 24px;
+}
+
+.legend-box {
+    display: inline-block;
+    width: 12px;
+    height: 12px;
+    border-radius: 4px;
+    margin-right: 6px;
+    border: 2px solid #e9ecef;
+    background: #f8fafc;
+}
+
+.legend-box.won {
+    background: #dcfce7;
+    border-color: #16a34a;
+}
+
+.legend-box.lost {
+    background: #fee2e2;
+    border-color: #dc2626;
+}
+
+.legend-box.pending {
+    background: #e2e8f0;
+    border-color: #cbd5f5;
+}
+
+.calendar-months {
+    display: flex;
+    flex-direction: column;
+    gap: 28px;
+}
+
+.calendar-month {
+    border: 2px solid #e9ecef;
+    border-radius: 18px;
+    padding: 20px;
+    background: #fff;
+}
+
+.calendar-month h3 {
+    font-size: 0.75rem;
+    margin-bottom: 12px;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    color: #0f172a;
+}
+
+.calendar-grid {
+    display: grid;
+    grid-template-columns: repeat(7, minmax(0, 1fr));
+    gap: 6px;
+}
+
+.calendar-day-label {
+    text-align: center;
+    font-size: 0.55rem;
+    color: #64748b;
+    padding: 4px 0;
+    text-transform: uppercase;
+}
+
+.calendar-cell,
+button.calendar-cell {
+    border: 2px solid #e9ecef;
+    border-radius: 12px;
+    min-height: 48px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-family: 'Press Start 2P', monospace;
+    font-size: 0.68rem;
+    background: #fff;
+    color: #0f172a;
+    cursor: default;
+    transition: border-color 0.2s, transform 0.2s;
+    padding: 0;
+}
+
+.calendar-cell.empty {
+    border: none;
+    background: transparent;
+}
+
+.calendar-cell[data-date] {
+    cursor: pointer;
+}
+
+.calendar-cell[data-date]:hover {
+    border-color: #0f172a;
+    transform: translateY(-1px);
+}
+
+button.calendar-cell {
+    width: 100%;
+}
+
+button.calendar-cell:focus-visible {
+    outline: 2px solid #0f172a;
+    outline-offset: 2px;
+}
+
+button.calendar-cell:disabled {
+    cursor: not-allowed;
+}
+
+.calendar-cell.won {
+    background: #dcfce7;
+    border-color: #16a34a;
+    color: #15803d;
+}
+
+.calendar-cell.lost {
+    background: #fee2e2;
+    border-color: #dc2626;
+    color: #b91c1c;
+}
+
+.calendar-cell.future {
+    background: #f1f5f9;
+    color: #94a3b8;
+}
+
+.calendar-cell.today:not(.won):not(.lost) {
+    border-color: #0f172a;
+}
+
+.calendar-cell.active {
+    box-shadow: 0 0 0 2px rgba(15, 23, 42, 0.35) inset;
+}
+
+.calendar-month-footer {
+    margin-top: 16px;
+    font-size: 0.6rem;
+    color: #475569;
+    text-align: center;
+}
+
+.calendar-note {
+    text-align: center;
+    font-size: 0.7rem;
+    color: #475569;
+    margin-top: 18px;
+}
+
+@media (max-width: 768px) {
+    .welcome-content {
+        margin: 32px auto;
+        padding: 28px 22px;
+    }
+
+    .welcome-title {
+        font-size: 0.9rem;
+    }
+
+    .welcome-subtitle {
+        font-size: 0.68rem;
+    }
+
+    .daily-challenge-body {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .daily-challenge-image {
+        width: 68px;
+        height: 68px;
+    }
+
+    .daily-challenge-question {
+        font-size: 0.78rem;
+    }
+
+    .primary-action {
+        font-size: 0.65rem;
+        padding: 14px 16px;
+    }
+
+    .secondary-action {
+        font-size: 0.58rem;
+        padding: 12px 14px;
+    }
+
+    .calendar-wrapper {
+        padding: 24px 20px 30px;
+        margin: 28px auto 48px;
+    }
+
+    .calendar-grid {
+        gap: 4px;
+    }
+
+    .calendar-cell,
+    button.calendar-cell {
+        min-height: 42px;
+        font-size: 0.6rem;
+    }
+
+    .nav-button {
+        font-size: 0.52rem;
+        padding: 9px 10px;
+    }
+}
+
+@media (max-width: 480px) {
+    .calendar-legend {
+        flex-direction: column;
+        align-items: center;
+        gap: 10px;
+    }
+
+    .calendar-cell,
+    button.calendar-cell {
+        min-height: 38px;
+    }
+
+    .daily-challenge-card {
+        padding: 18px;
+    }
 }
 
 /* Large screens (>768px) - Show images side by side */


### PR DESCRIPTION
## Summary
- add a welcome screen, calendar view, and updated navigation to index.html
- extend styles to support the welcome hero, calendar, and header navigation controls
- finalize SPA routing, calendar rendering, and button handlers to switch between views and resume questions

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cbdf12890c832986d5f4214527451b