### PR TITLE
Make bottom sections sticky only when necessary

### DIFF
--- a/script.js
+++ b/script.js
@@ -3245,5 +3245,4 @@ document.addEventListener('click', (e) => {
 // Initialize the game when the page loads
 window.addEventListener('resize', updateConfidenceInputVisibility);
 window.addEventListener('resize', updateFooterPositioning);
-window.addEventListener('scroll', scheduleFooterPositioningUpdate, { passive: true });
 document.addEventListener('DOMContentLoaded', initGame);

--- a/script.js
+++ b/script.js
@@ -1042,6 +1042,16 @@ function updateFooterPositioning() {
         gameContainer.classList.toggle('has-sticky-footer', shouldAddPadding);
     }
 }
+
+let footerUpdateScheduled = false;
+function scheduleFooterPositioningUpdate() {
+    if (footerUpdateScheduled) return;
+    footerUpdateScheduled = true;
+    requestAnimationFrame(() => {
+        footerUpdateScheduled = false;
+        updateFooterPositioning();
+    });
+}
 const newGameBtnInline = document.getElementById('new-game-btn-inline');
 const gameOverModal = document.getElementById('game-over-modal');
 const modalTitle = document.getElementById('modal-title');
@@ -3022,6 +3032,7 @@ function setupEventListeners() {
                 hintContainer.classList.add('open');
                 hintModalBtn.setAttribute('aria-expanded', 'true');
             }
+            scheduleFooterPositioningUpdate();
         });
     }
     
@@ -3177,6 +3188,7 @@ function setupEventListeners() {
                 item.classList.add('open');
                 header.setAttribute('aria-expanded', 'true');
             }
+            scheduleFooterPositioningUpdate();
         });
     });
     
@@ -3233,4 +3245,5 @@ document.addEventListener('click', (e) => {
 // Initialize the game when the page loads
 window.addEventListener('resize', updateConfidenceInputVisibility);
 window.addEventListener('resize', updateFooterPositioning);
+window.addEventListener('scroll', scheduleFooterPositioningUpdate, { passive: true });
 document.addEventListener('DOMContentLoaded', initGame);

--- a/script.js
+++ b/script.js
@@ -1007,6 +1007,8 @@ const sendIcon = `\
   <path d="M2 21L23 12L2 3v7l12 2L2 14v7z"/>
 </svg>`;
 const inputSection = document.getElementById('input-section');
+const newGameSection = document.getElementById('new-game-section');
+const gameContainer = document.querySelector('.game-container');
 
 function resetConfidenceInput() {
     if (confidenceInput) confidenceInput.value = '';
@@ -1015,7 +1017,31 @@ function resetConfidenceInput() {
         confidenceMenu.querySelectorAll('.selected').forEach(btn => btn.classList.remove('selected'));
     }
 }
-const newGameSection = document.getElementById('new-game-section');
+
+function updateFooterPositioning() {
+    const sections = [inputSection, newGameSection];
+    let shouldAddPadding = false;
+
+    sections.forEach(section => {
+        if (section) {
+            section.classList.remove('sticky-footer');
+        }
+    });
+
+    sections.forEach(section => {
+        if (!section) return;
+        if (section.offsetParent === null) return;
+        const rect = section.getBoundingClientRect();
+        if (rect.bottom > window.innerHeight) {
+            section.classList.add('sticky-footer');
+            shouldAddPadding = true;
+        }
+    });
+
+    if (gameContainer) {
+        gameContainer.classList.toggle('has-sticky-footer', shouldAddPadding);
+    }
+}
 const newGameBtnInline = document.getElementById('new-game-btn-inline');
 const gameOverModal = document.getElementById('game-over-modal');
 const modalTitle = document.getElementById('modal-title');
@@ -1099,18 +1125,19 @@ function initGame() {
     setupEventListeners();
     // Always initialize routing; allow it to handle future navigations
     initRouting(false);
+    updateFooterPositioning();
 }
 
 // Update question display including image
 function updateQuestionDisplay(question) {
     questionText.textContent = question.question;
     questionCategory.innerHTML = getQuestionDisplayText(question); // Use innerHTML to allow <span>
-    
+
     // Update question image
     if (question.image) {
         // Hide container initially while loading
         questionImageContainer.style.display = 'none';
-        
+
         // Create a new image element to test loading
         const testImg = new Image();
         testImg.onload = function() {
@@ -1118,19 +1145,24 @@ function updateQuestionDisplay(question) {
             questionImage.src = question.image;
             questionImage.alt = `Image for ${question.question}`;
             questionImageContainer.style.display = 'block';
+            updateFooterPositioning();
         };
         testImg.onerror = function() {
             // Image failed to load, hide container
             console.log('Failed to load image:', question.image);
             questionImageContainer.style.display = 'none';
+            updateFooterPositioning();
         };
         testImg.src = question.image;
+        updateFooterPositioning();
     } else {
         questionImageContainer.style.display = 'none';
+        updateFooterPositioning();
     }
 
     updateCommentCount();
     subscribeToComments(question.date);
+    updateFooterPositioning();
 }
 
 // Start a new game
@@ -1174,6 +1206,7 @@ function startNewGame() {
     inputSection.style.display = 'block';
     newGameSection.style.display = 'none';
     shareBtn.style.display = 'none'; // Hide share button for new game
+    updateFooterPositioning();
     // Nudge attention to the counter on initial start (mobile only)
     triggerShake(guessCounter);
     
@@ -1777,6 +1810,7 @@ function endGame() {
 
     // Simple scroll to top to ensure good positioning
     window.scrollTo(0, 0);
+    updateFooterPositioning();
 }
 
 // Start a new game
@@ -2322,6 +2356,7 @@ function loadCurrentGameState() {
             if (!('ontouchstart' in window) && !navigator.maxTouchPoints) {
                 setTimeout(() => guessInput.focus(), 100);
             }
+            updateFooterPositioning();
         }
 
             // Ensure confidence input visibility matches current state
@@ -2469,6 +2504,7 @@ function endGameDisplay() {
         newGameBtnInline.textContent = 'Play more';
         newGameBtnInline.onclick = startNewGame;
     }
+    updateFooterPositioning();
 }
 
 // Show questions history modal
@@ -2715,6 +2751,7 @@ function selectQuestion(question) {
 
         // Show confidence input for first guess only
         updateConfidenceInputVisibility();
+        updateFooterPositioning();
     }
 }
 
@@ -3195,4 +3232,5 @@ document.addEventListener('click', (e) => {
 
 // Initialize the game when the page loads
 window.addEventListener('resize', updateConfidenceInputVisibility);
+window.addEventListener('resize', updateFooterPositioning);
 document.addEventListener('DOMContentLoaded', initGame);

--- a/styles.css
+++ b/styles.css
@@ -25,6 +25,10 @@ button {
     margin: 0 auto;
     border-radius: 18px;
     position: relative;
+    padding-bottom: 30px;
+}
+
+.game-container.has-sticky-footer {
     padding-bottom: 134px;
 }
 
@@ -581,13 +585,17 @@ button#stats-btn {
 /* Input Section */
 .input-section,
 .new-game-section {
+    width: min(500px, calc(100% - 36px));
+    margin: 16px auto 0;
+    padding-bottom: 18px;
+}
+
+.sticky-footer {
     position: fixed;
     left: 50%;
     transform: translateX(-50%);
-    width: min(500px, calc(100% - 36px));
     bottom: calc(0px + env(safe-area-inset-bottom));
     z-index: 900;
-    padding-bottom: 18px;
     margin-top: 0;
 }
 

--- a/styles.css
+++ b/styles.css
@@ -586,12 +586,13 @@ button#stats-btn {
 .input-section,
 .new-game-section {
     width: min(500px, calc(100% - 36px));
-    margin: 16px auto 0;
+    margin: 20px auto 0;
     padding-bottom: 18px;
 }
 
 .sticky-footer {
     position: fixed;
+    width: min(500px, calc(100% - 36px));
     left: 50%;
     transform: translateX(-50%);
     bottom: calc(0px + env(safe-area-inset-bottom));

--- a/styles.css
+++ b/styles.css
@@ -462,7 +462,6 @@ button#stats-btn {
 
 /* Guesses Container */
 .guesses-container {
-    margin-bottom: 20px;
     position: relative;
     z-index: 6; /* ensure tooltips above .question-box (z-index:5) */
 }
@@ -1187,10 +1186,6 @@ button#stats-btn {
     .game-header {
         padding: 18px 0;
     }
-    .game-container {
-        padding: 0 0 134px;
-        border-radius: 18px;
-    }
     .question-box {
         border-radius: 16px;
         padding: 20px;
@@ -1198,9 +1193,6 @@ button#stats-btn {
     .feedback-button::after {
         width: 98px;
         white-space: normal;
-    }
-    .guesses-container {
-        margin-bottom: 0px;
     }
     .guess-counter,
     .hint-container {

--- a/styles.css
+++ b/styles.css
@@ -585,8 +585,7 @@ button#stats-btn {
 /* Input Section */
 .input-section,
 .new-game-section {
-    width: min(500px, calc(100% - 36px));
-    margin: 20px auto 0;
+    margin-top: 20px;
     padding-bottom: 18px;
 }
 


### PR DESCRIPTION
## Summary
- add a reusable sticky-footer class and toggle game container padding based on whether footers need to stick
- recalculate footer positioning on game state changes, image loads, and viewport resize events so sections only fix to the bottom when out of view

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cc23d129d883299a36ccfc379f91ae