### PR TITLE
Make bottom sections sticky only when necessary

### DIFF
--- a/script.js
+++ b/script.js
@@ -1020,13 +1020,22 @@ function resetConfidenceInput() {
 
 function updateFooterPositioning() {
     const sections = [inputSection, newGameSection];
-    let shouldAddPadding = false;
 
     sections.forEach(section => {
         if (section) {
             section.classList.remove('sticky-footer');
         }
     });
+
+    const allowSticky = !isSmallDevice();
+    if (!allowSticky) {
+        if (gameContainer) {
+            gameContainer.classList.remove('has-sticky-footer');
+        }
+        return;
+    }
+
+    let shouldAddPadding = false;
 
     sections.forEach(section => {
         if (!section) return;
@@ -1041,6 +1050,16 @@ function updateFooterPositioning() {
     if (gameContainer) {
         gameContainer.classList.toggle('has-sticky-footer', shouldAddPadding);
     }
+}
+
+let footerUpdateScheduled = false;
+function scheduleFooterPositioningUpdate() {
+    if (footerUpdateScheduled) return;
+    footerUpdateScheduled = true;
+    requestAnimationFrame(() => {
+        footerUpdateScheduled = false;
+        updateFooterPositioning();
+    });
 }
 const newGameBtnInline = document.getElementById('new-game-btn-inline');
 const gameOverModal = document.getElementById('game-over-modal');
@@ -3022,6 +3041,7 @@ function setupEventListeners() {
                 hintContainer.classList.add('open');
                 hintModalBtn.setAttribute('aria-expanded', 'true');
             }
+            scheduleFooterPositioningUpdate();
         });
     }
     
@@ -3177,6 +3197,7 @@ function setupEventListeners() {
                 item.classList.add('open');
                 header.setAttribute('aria-expanded', 'true');
             }
+            scheduleFooterPositioningUpdate();
         });
     });
     

--- a/styles.css
+++ b/styles.css
@@ -585,13 +585,13 @@ button#stats-btn {
 /* Input Section */
 .input-section,
 .new-game-section {
-    width: min(500px, calc(100% - 36px));
-    margin: 16px auto 0;
+    margin-top: 20px;
     padding-bottom: 18px;
 }
 
 .sticky-footer {
     position: fixed;
+    width: min(500px, calc(100% - 36px));
     left: 50%;
     transform: translateX(-50%);
     bottom: calc(0px + env(safe-area-inset-bottom));


### PR DESCRIPTION
## Summary
- add a reusable sticky-footer class and toggle game container padding based on whether footers need to stick
- recalculate footer positioning on game state changes, image loads, and viewport resize events so sections only fix to the bottom when out of view
- align sticky footer layout with inline spacing requirements without overriding section widths, and keep scheduled hint/accordion updates
- disable sticky footers on small viewports so the behavior is desktop-only

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cc2c94d3188329bd05408fdd370e48