### PR TITLE
Add dedicated help and stats views with navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -297,8 +297,8 @@
                         </button>
                         <div class="accordion-panel" id="acc-initial-panel">
                             <div id="source-initial" style="margin-top: 0;">
-                                <p id="median-first-guess-text"></p>
-                                <p id="first-guess-percentile-text"></p>
+                                <p id="median-first-guess-text" data-median-first-guess></p>
+                                <p id="first-guess-percentile-text" data-first-guess-percentile></p>
                             </div>
                         </div>
                     </div>
@@ -320,27 +320,27 @@
                         <div class="accordion-panel" id="acc-statsgrid-panel">
                             <div class="stats-grid">
                                 <div class="stat-item">
-                                    <span class="stat-number" id="games-played">0</span>
+                                    <span class="stat-number" id="games-played" data-stat-field="games-played">0</span>
                                     <span class="stat-label">Games Played</span>
                                 </div>
                                 <div class="stat-item">
-                                    <span class="stat-number" id="games-won">0</span>
+                                    <span class="stat-number" id="games-won" data-stat-field="games-won">0</span>
                                     <span class="stat-label">Games Won</span>
                                 </div>
                                 <div class="stat-item">
-                                    <span class="stat-number" id="win-rate">0%</span>
+                                    <span class="stat-number" id="win-rate" data-stat-field="win-rate">0%</span>
                                     <span class="stat-label">Win Rate</span>
                                 </div>
                                 <div class="stat-item">
-                                    <span class="stat-number" id="current-streak">0</span>
+                                    <span class="stat-number" id="current-streak" data-stat-field="current-streak">0</span>
                                     <span class="stat-label">Current Streak</span>
                                 </div>
                                 <div class="stat-item">
-                                    <span class="stat-number" id="max-streak">0</span>
+                                    <span class="stat-number" id="max-streak" data-stat-field="max-streak">0</span>
                                     <span class="stat-label">Max Streak</span>
                                 </div>
                                 <div class="stat-item">
-                                    <span class="stat-number" id="guess-average">0</span>
+                                    <span class="stat-number" id="guess-average" data-stat-field="guess-average">0</span>
                                     <span class="stat-label">Guess Average</span>
                                 </div>
                             </div>
@@ -353,50 +353,50 @@
                         </button>
                         <div class="accordion-panel" id="acc-distribution-panel">
                             <div class="guess-distribution">
-                                <div class="distribution-bars">
-                                    <div class="dist-row">
-                                        <span class="dist-label">1</span>
-                                        <div class="dist-bar-container">
-                                            <div class="dist-bar" id="dist-1" style="width: 0%"></div>
+                                    <div class="distribution-bars">
+                                        <div class="dist-row">
+                                            <span class="dist-label">1</span>
+                                            <div class="dist-bar-container">
+                                            <div class="dist-bar" id="dist-1" data-dist-bar="1" style="width: 0%"></div>
+                                            </div>
+                                            <span class="dist-count" id="count-1" data-dist-count="1">0</span>
                                         </div>
-                                        <span class="dist-count" id="count-1">0</span>
-                                    </div>
-                                    <div class="dist-row">
-                                        <span class="dist-label">2</span>
-                                        <div class="dist-bar-container">
-                                            <div class="dist-bar" id="dist-2" style="width: 0%"></div>
+                                        <div class="dist-row">
+                                            <span class="dist-label">2</span>
+                                            <div class="dist-bar-container">
+                                            <div class="dist-bar" id="dist-2" data-dist-bar="2" style="width: 0%"></div>
+                                            </div>
+                                            <span class="dist-count" id="count-2" data-dist-count="2">0</span>
                                         </div>
-                                        <span class="dist-count" id="count-2">0</span>
-                                    </div>
-                                    <div class="dist-row">
-                                        <span class="dist-label">3</span>
-                                        <div class="dist-bar-container">
-                                            <div class="dist-bar" id="dist-3" style="width: 0%"></div>
+                                        <div class="dist-row">
+                                            <span class="dist-label">3</span>
+                                            <div class="dist-bar-container">
+                                            <div class="dist-bar" id="dist-3" data-dist-bar="3" style="width: 0%"></div>
+                                            </div>
+                                            <span class="dist-count" id="count-3" data-dist-count="3">0</span>
                                         </div>
-                                        <span class="dist-count" id="count-3">0</span>
-                                    </div>
-                                    <div class="dist-row">
-                                        <span class="dist-label">4</span>
-                                        <div class="dist-bar-container">
-                                            <div class="dist-bar" id="dist-4" style="width: 0%"></div>
+                                        <div class="dist-row">
+                                            <span class="dist-label">4</span>
+                                            <div class="dist-bar-container">
+                                            <div class="dist-bar" id="dist-4" data-dist-bar="4" style="width: 0%"></div>
+                                            </div>
+                                            <span class="dist-count" id="count-4" data-dist-count="4">0</span>
                                         </div>
-                                        <span class="dist-count" id="count-4">0</span>
-                                    </div>
-                                    <div class="dist-row">
-                                        <span class="dist-label">5</span>
-                                        <div class="dist-bar-container">
-                                            <div class="dist-bar" id="dist-5" style="width: 0%"></div>
+                                        <div class="dist-row">
+                                            <span class="dist-label">5</span>
+                                            <div class="dist-bar-container">
+                                            <div class="dist-bar" id="dist-5" data-dist-bar="5" style="width: 0%"></div>
+                                            </div>
+                                            <span class="dist-count" id="count-5" data-dist-count="5">0</span>
                                         </div>
-                                        <span class="dist-count" id="count-5">0</span>
-                                    </div>
-                                    <div class="dist-row">
-                                        <span class="dist-label">6</span>
-                                        <div class="dist-bar-container">
-                                            <div class="dist-bar" id="dist-6" style="width: 0%"></div>
+                                        <div class="dist-row">
+                                            <span class="dist-label">6</span>
+                                            <div class="dist-bar-container">
+                                            <div class="dist-bar" id="dist-6" data-dist-bar="6" style="width: 0%"></div>
+                                            </div>
+                                            <span class="dist-count" id="count-6" data-dist-count="6">0</span>
                                         </div>
-                                        <span class="dist-count" id="count-6">0</span>
                                     </div>
-                                </div>
                             </div>
                         </div>
                     </div>
@@ -411,20 +411,20 @@
                                     <input type="checkbox" id="prob-calibration-checkbox-stats" class="prob-calibration-checkbox" checked> Enable probability calibration mode
                                 </label>
                                 <label>
-                                    <input type="checkbox" id="first-guess-checkbox"> Only count first guesses
+                                    <input type="checkbox" id="first-guess-checkbox" data-first-guess-checkbox> Only count first guesses
                                 </label>
                             </div>
-                            <p class="calibration-note">No data yet</p>
+                            <p class="calibration-note" data-calibration-note="modal">No data yet</p>
                             <div class="calibration-chart-wrapper">
-                                <svg id="calibration-chart" width="300" height="200"></svg>
+                                <svg id="calibration-chart" data-calibration-chart="modal" width="300" height="200"></svg>
                             </div>
                             <p class="calibration-description">The x-axis shows your declared confidence, and the y-axis shows the actual accuracy. You are perfectly calibrated if you are on the diagonal line.</p>
-                            <div id="calibration-tooltip" class="chart-tooltip"></div>
+                            <div id="calibration-tooltip" class="chart-tooltip" data-calibration-tooltip="modal"></div>
                         </div>
                     </div>
                 </div>
 
-                <button id="share-stats-btn" class="share-btn">Share</button>
+                <button id="share-stats-btn" class="share-btn share-stats-btn">Share</button>
                 <button id="close-stats-btn" class="close-btn">Close</button>
             </div>
         </div>
@@ -433,7 +433,10 @@
 
         <section id="calendar-view" class="view">
             <div class="calendar-wrapper">
-                <h2 class="calendar-title">Question Calendar</h2>
+                <div class="calendar-header">
+                    <button type="button" class="back-button" id="calendar-back-btn">&lt; Back</button>
+                    <h2 class="calendar-title">Question Calendar</h2>
+                </div>
                 <p class="calendar-subtitle">Pick a day to play or review its challenge.</p>
                 <div class="calendar-legend">
                     <span><span class="legend-box pending"></span> Not played</span>
@@ -441,6 +444,177 @@
                     <span><span class="legend-box lost"></span> Missed</span>
                 </div>
                 <div id="calendar-months" class="calendar-months"></div>
+            </div>
+        </section>
+
+        <section id="help-view" class="view">
+            <div class="info-view-card">
+                <div class="view-header">
+                    <button type="button" class="back-button" id="help-back-btn">&lt; Back</button>
+                    <h2>How to Play</h2>
+                </div>
+                <div class="view-body">
+                    <div class="accordion" id="help-accordion-view">
+                        <div class="accordion-item" id="acc-calibration-help-item-view">
+                            <button class="accordion-header" id="acc-calibration-help-header-view" aria-expanded="false" aria-controls="acc-calibration-help-panel-view">
+                                <span>Probability Calibration</span>
+                                <span class="acc-arrow">></span>
+                            </button>
+                            <div class="accordion-panel" id="acc-calibration-help-panel-view">
+                                <p>When the probability calibration mode is enabled, you are able to log your confidence with each guess and track how well your probabilities match reality.</p>
+                                <p>A calibration chart showing whether you're over- or underconfident is available on the stats page.</p>
+                                <label><input type="checkbox" class="prob-calibration-checkbox" checked> Enable probability calibration mode</label>
+                            </div>
+                        </div>
+                        <div class="accordion-item" id="acc-strategy-item-view">
+                            <button class="accordion-header" id="acc-strategy-header-view" aria-expanded="false" aria-controls="acc-strategy-panel-view">
+                                <span>Strategy tip</span>
+                                <span class="acc-arrow">></span>
+                            </button>
+                            <div class="accordion-panel" id="acc-strategy-panel-view">
+                                <p>Make a Fermi estimate: break the problem into simple factors, choose round numbers, then multiply.</p>
+                                <p>Example: How many new cars are sold annually in Japan?</p>
+                                <p>Population a little over 100M -> about 50M households -> roughly 80% own a car -> 40M cars. If cars are replaced about every 10 years, that means roughly 4M new cars sold per year.</p>
+                            </div>
+                        </div>
+                        <div class="accordion-item open" id="acc-overview-item-view">
+                            <button class="accordion-header" id="acc-overview-header-view" aria-expanded="true" aria-controls="acc-overview-panel-view">
+                                <span>Overview</span>
+                                <span class="acc-arrow">></span>
+                            </button>
+                            <div class="accordion-panel" id="acc-overview-panel-view">
+                                <p>Guess the answer to estimation questions in 6 or less tries.</p>
+                                <p>After each guess, you'll see if your answer was too high or too low. An arrow pointing down means that the correct answer is below your guess.</p>
+                                <p>The color of the arrows shows how close you are: orange indicates your guess is within ±50% of the answer, red means it is further away</p>
+                                <p>You win if your guess is within ±20% of the correct answer.</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section id="stats-view" class="view">
+            <div class="info-view-card">
+                <div class="view-header">
+                    <button type="button" class="back-button" id="stats-back-btn">&lt; Back</button>
+                    <h2>Statistics</h2>
+                </div>
+                <div class="view-body">
+                    <div class="accordion" id="stats-accordion-view">
+                        <div class="accordion-item open" id="acc-statsgrid-item-view">
+                            <button class="accordion-header" id="acc-statsgrid-header-view" aria-expanded="true" aria-controls="acc-statsgrid-panel-view">
+                                <span>Stats</span>
+                                <span class="acc-arrow">></span>
+                            </button>
+                            <div class="accordion-panel" id="acc-statsgrid-panel-view">
+                                <div class="stats-grid">
+                                    <div class="stat-item">
+                                        <span class="stat-number" data-stat-field="games-played">0</span>
+                                        <span class="stat-label">Games Played</span>
+                                    </div>
+                                    <div class="stat-item">
+                                        <span class="stat-number" data-stat-field="games-won">0</span>
+                                        <span class="stat-label">Games Won</span>
+                                    </div>
+                                    <div class="stat-item">
+                                        <span class="stat-number" data-stat-field="win-rate">0%</span>
+                                        <span class="stat-label">Win Rate</span>
+                                    </div>
+                                    <div class="stat-item">
+                                        <span class="stat-number" data-stat-field="current-streak">0</span>
+                                        <span class="stat-label">Current Streak</span>
+                                    </div>
+                                    <div class="stat-item">
+                                        <span class="stat-number" data-stat-field="max-streak">0</span>
+                                        <span class="stat-label">Max Streak</span>
+                                    </div>
+                                    <div class="stat-item">
+                                        <span class="stat-number" data-stat-field="guess-average">0</span>
+                                        <span class="stat-label">Guess Average</span>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="accordion-item" id="acc-distribution-item-view">
+                            <button class="accordion-header" id="acc-distribution-header-view" aria-expanded="false" aria-controls="acc-distribution-panel-view">
+                                <span>Guess Distribution</span>
+                                <span class="acc-arrow">></span>
+                            </button>
+                            <div class="accordion-panel" id="acc-distribution-panel-view">
+                                <div class="guess-distribution">
+                                    <div class="distribution-bars">
+                                        <div class="dist-row">
+                                            <span class="dist-label">1</span>
+                                            <div class="dist-bar-container">
+                                                <div class="dist-bar" data-dist-bar="1" style="width: 0%"></div>
+                                            </div>
+                                            <span class="dist-count" data-dist-count="1">0</span>
+                                        </div>
+                                        <div class="dist-row">
+                                            <span class="dist-label">2</span>
+                                            <div class="dist-bar-container">
+                                                <div class="dist-bar" data-dist-bar="2" style="width: 0%"></div>
+                                            </div>
+                                            <span class="dist-count" data-dist-count="2">0</span>
+                                        </div>
+                                        <div class="dist-row">
+                                            <span class="dist-label">3</span>
+                                            <div class="dist-bar-container">
+                                                <div class="dist-bar" data-dist-bar="3" style="width: 0%"></div>
+                                            </div>
+                                            <span class="dist-count" data-dist-count="3">0</span>
+                                        </div>
+                                        <div class="dist-row">
+                                            <span class="dist-label">4</span>
+                                            <div class="dist-bar-container">
+                                                <div class="dist-bar" data-dist-bar="4" style="width: 0%"></div>
+                                            </div>
+                                            <span class="dist-count" data-dist-count="4">0</span>
+                                        </div>
+                                        <div class="dist-row">
+                                            <span class="dist-label">5</span>
+                                            <div class="dist-bar-container">
+                                                <div class="dist-bar" data-dist-bar="5" style="width: 0%"></div>
+                                            </div>
+                                            <span class="dist-count" data-dist-count="5">0</span>
+                                        </div>
+                                        <div class="dist-row">
+                                            <span class="dist-label">6</span>
+                                            <div class="dist-bar-container">
+                                                <div class="dist-bar" data-dist-bar="6" style="width: 0%"></div>
+                                            </div>
+                                            <span class="dist-count" data-dist-count="6">0</span>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="accordion-item open" id="acc-calibration-item-view">
+                            <button class="accordion-header" id="acc-calibration-header-view" aria-expanded="true" aria-controls="acc-calibration-panel-view">
+                                <span>Probability Calibration</span>
+                                <span class="acc-arrow">></span>
+                            </button>
+                            <div class="accordion-panel" id="acc-calibration-panel-view">
+                                <div class="calibration-options">
+                                    <label>
+                                        <input type="checkbox" class="prob-calibration-checkbox" checked> Enable probability calibration mode
+                                    </label>
+                                    <label>
+                                        <input type="checkbox" data-first-guess-checkbox> Only count first guesses
+                                    </label>
+                                </div>
+                                <p class="calibration-note" data-calibration-note="view">No data yet</p>
+                                <div class="calibration-chart-wrapper">
+                                    <svg id="calibration-chart-view" data-calibration-chart="view" width="300" height="200"></svg>
+                                </div>
+                                <p class="calibration-description">The x-axis shows your declared confidence, and the y-axis shows the actual accuracy. You are perfectly calibrated if you are on the diagonal line.</p>
+                                <div class="chart-tooltip" data-calibration-tooltip="view"></div>
+                            </div>
+                        </div>
+                    </div>
+                    <button type="button" class="share-btn share-stats-btn">Share</button>
+                </div>
             </div>
         </section>
     </main>

--- a/script.js
+++ b/script.js
@@ -439,6 +439,7 @@ let completedQuestions = {}; // Changed from array to object to track win/loss s
 // URL Routing state
 let isNavigating = false;
 let currentView = 'welcome';
+const viewHistory = [];
 let todaysQuestion = null;
 
 // Statistics
@@ -982,6 +983,8 @@ const fermiQuestions = [
 const welcomeScreen = document.getElementById('welcome-screen');
 const gameView = document.getElementById('game-view');
 const calendarView = document.getElementById('calendar-view');
+const helpView = document.getElementById('help-view');
+const statsView = document.getElementById('stats-view');
 const playDailyBtn = document.getElementById('play-daily-btn');
 const calendarLinkBtn = document.getElementById('calendar-link-btn');
 const homeBtn = document.getElementById('home-btn');
@@ -1043,6 +1046,9 @@ const helpModal = document.getElementById('help-modal');
 const statsModal = document.getElementById('stats-modal');
 const questionsModal = document.getElementById('questions-modal');
 const strategyTipsBtn = document.getElementById('strategy-tips-btn');
+const helpBackBtn = document.getElementById('help-back-btn');
+const statsBackBtn = document.getElementById('stats-back-btn');
+const calendarBackBtn = document.getElementById('calendar-back-btn');
 // Hint elements
 const hintModalBtn = document.getElementById('hint-modal-btn');
 const questionsList = document.getElementById('questions-list');
@@ -1050,14 +1056,20 @@ const closeHelpBtn = document.getElementById('close-help-btn');
 const closeStatsBtn = document.getElementById('close-stats-btn');
 const closeQuestionsBtn = document.getElementById('close-questions-btn');
 const shareBtn = document.getElementById('share-btn');
-const shareStatsBtn = document.getElementById('share-stats-btn');
-const medianFirstGuessText = document.getElementById('median-first-guess-text');
-const firstGuessPercentileText = document.getElementById('first-guess-percentile-text');
+const shareStatsButtons = document.querySelectorAll('.share-stats-btn');
+const medianFirstGuessElements = document.querySelectorAll('[data-median-first-guess]');
+const firstGuessPercentileElements = document.querySelectorAll('[data-first-guess-percentile]');
 const calibrationCheckboxes = document.querySelectorAll('.prob-calibration-checkbox');
-const firstGuessCheckbox = document.getElementById('first-guess-checkbox');
-const calibrationChart = document.getElementById('calibration-chart');
-const calibrationTooltip = document.getElementById('calibration-tooltip');
-const calibrationNote = document.querySelector('.calibration-note');
+const firstGuessCheckboxes = document.querySelectorAll('[data-first-guess-checkbox]');
+const calibrationCharts = document.querySelectorAll('[data-calibration-chart]');
+const calibrationTooltips = new Map();
+document.querySelectorAll('[data-calibration-tooltip]').forEach(el => {
+    calibrationTooltips.set(el.dataset.calibrationTooltip || 'default', el);
+});
+const calibrationNotes = new Map();
+document.querySelectorAll('[data-calibration-note]').forEach(el => {
+    calibrationNotes.set(el.dataset.calibrationNote || 'default', el);
+});
 const commentsBtn = document.getElementById('comments-btn');
 const commentsSection = document.getElementById('comments-section');
 const commentsBackBtn = document.getElementById('comments-back-btn');
@@ -1363,14 +1375,23 @@ function updateHash(newHash) {
 }
 
 function setActiveView(view, options = {}) {
-    const { skipURLUpdate = false, force = false } = options;
+    const { skipURLUpdate = false, force = false, fromHistory = false } = options;
     if (!force && currentView === view) {
         if (view === 'calendar') {
             renderCalendar();
         } else if (view === 'welcome') {
             refreshDailyChallengeSummary();
+        } else if (view === 'stats') {
+            updateStatsDisplay();
         }
         return;
+    }
+
+    if (!fromHistory && currentView && currentView !== view) {
+        const last = viewHistory[viewHistory.length - 1];
+        if (last !== currentView) {
+            viewHistory.push(currentView);
+        }
     }
 
     currentView = view;
@@ -1384,12 +1405,20 @@ function setActiveView(view, options = {}) {
     if (calendarView) {
         calendarView.classList.toggle('active', view === 'calendar');
     }
+    if (helpView) {
+        helpView.classList.toggle('active', view === 'help');
+    }
+    if (statsView) {
+        statsView.classList.toggle('active', view === 'stats');
+    }
 
     if (!skipURLUpdate) {
         if (view === 'welcome') {
             updateHash('#/welcome');
         } else if (view === 'calendar') {
             updateHash('#/calendar');
+        } else if (view === 'game' && currentQuestion) {
+            updateURL(currentQuestion.date);
         }
     }
 
@@ -1401,7 +1430,24 @@ function setActiveView(view, options = {}) {
         if (guessInput && !('ontouchstart' in window) && !navigator.maxTouchPoints) {
             setTimeout(() => guessInput.focus(), 150);
         }
+    } else if (view === 'stats') {
+        updateStatsDisplay();
     }
+
+    if (view !== 'stats') {
+        hideCalibrationTooltip();
+    }
+}
+
+function navigateBack(fallbackView = 'welcome') {
+    while (viewHistory.length > 0) {
+        const previous = viewHistory.pop();
+        if (previous && previous !== currentView) {
+            setActiveView(previous, { force: true, fromHistory: true });
+            return;
+        }
+    }
+    setActiveView(fallbackView, { force: true, fromHistory: true });
 }
 
 function renderCalendar() {
@@ -2074,94 +2120,118 @@ function startNewGameFromModal() {
     startNewGame();
 }
 
-// Show help modal
-function showHelp() {
-    helpModal.style.display = 'block';
+// Show help modal or view
+function showHelp(options = {}) {
+    const { asModal = false } = options;
+    if (!asModal && helpView) {
+        setActiveView('help', { skipURLUpdate: true });
+        window.scrollTo(0, 0);
+        return;
+    }
+    if (helpModal) {
+        helpModal.style.display = 'block';
+    }
 }
 
-// Show stats modal
-function showStats() {
+// Show stats modal or view
+function showStats(options = {}) {
     updateStatsDisplay();
-    statsModal.style.display = 'block';
+    const { asModal = false } = options;
+    if (!asModal && statsView) {
+        setActiveView('stats', { skipURLUpdate: true });
+        window.scrollTo(0, 0);
+        return;
+    }
+    if (statsModal) {
+        statsModal.style.display = 'block';
+    }
 }
 
 // Update stats display
+function setStatField(field, value) {
+    document.querySelectorAll(`[data-stat-field="${field}"]`).forEach(el => {
+        el.textContent = value;
+    });
+}
+
 function updateStatsDisplay() {
-    document.getElementById('games-played').textContent = stats.gamesPlayed;
-    document.getElementById('games-won').textContent = stats.gamesWon;
-    document.getElementById('win-rate').textContent = `${stats.winRate}%`;
-    document.getElementById('current-streak').textContent = stats.currentStreak;
-    document.getElementById('max-streak').textContent = stats.maxStreak;
-    
-    // Compute Guess Average (count losses as 7 guesses)
-    const guessAverageElement = document.getElementById('guess-average');
-    if (guessAverageElement) {
-        try {
-            const completed = completedQuestions || {};
-            const games = Object.values(completed);
-            const totalGames = games.length;
-            if (totalGames === 0) {
-                guessAverageElement.textContent = '0';
-            } else {
-                const totalRatedGuesses = games.reduce((sum, game) => {
-                    const won = !!game.won;
-                    const guessesUsed = Number(game.guesses) || 0;
-                    return sum + (won ? guessesUsed : 7);
-                }, 0);
-                const average = totalRatedGuesses / totalGames;
-                guessAverageElement.textContent = Number.isInteger(average) ? `${average}` : average.toFixed(1);
-            }
-        } catch (e) {
-            guessAverageElement.textContent = '0';
+    setStatField('games-played', stats.gamesPlayed);
+    setStatField('games-won', stats.gamesWon);
+    setStatField('win-rate', `${stats.winRate}%`);
+    setStatField('current-streak', stats.currentStreak);
+    setStatField('max-streak', stats.maxStreak);
+
+    let guessAverageValue = '0';
+    try {
+        const completed = completedQuestions || {};
+        const games = Object.values(completed);
+        const totalGames = games.length;
+        if (totalGames === 0) {
+            guessAverageValue = '0';
+        } else {
+            const totalRatedGuesses = games.reduce((sum, game) => {
+                const won = !!game.won;
+                const guessesUsed = Number(game.guesses) || 0;
+                return sum + (won ? guessesUsed : 7);
+            }, 0);
+            const average = totalRatedGuesses / totalGames;
+            guessAverageValue = Number.isInteger(average) ? `${average}` : average.toFixed(1);
         }
+    } catch (e) {
+        guessAverageValue = '0';
     }
-    
-    // Update guess distribution
+    setStatField('guess-average', guessAverageValue);
+
     const guessDist = stats.guessDistribution || {};
     const maxWins = Math.max(...Object.values(guessDist), 0);
-    
+
     for (let i = 1; i <= 6; i++) {
         const count = guessDist[i] || 0;
         const percentage = maxWins > 0 ? (count / maxWins) * 100 : 0;
-        
-        const countElement = document.getElementById(`count-${i}`);
-        const barElement = document.getElementById(`dist-${i}`);
-        
-        if (countElement && barElement) {
-            countElement.textContent = count;
-            barElement.style.width = `${percentage}%`;
-        }
+
+        document.querySelectorAll(`[data-dist-count="${i}"]`).forEach(el => {
+            el.textContent = count;
+        });
+
+        document.querySelectorAll(`[data-dist-bar="${i}"]`).forEach(el => {
+            el.style.width = `${percentage}%`;
+        });
     }
 
     updateCalibrationChart();
 }
 
-function showCalibrationTooltip(evt, sampleSize, declared, actual) {
-    if (!calibrationTooltip) return;
+function showCalibrationTooltip(evt, sampleSize, declared, actual, group = 'default') {
+    const tooltip = calibrationTooltips.get(group);
+    if (!tooltip) return;
     const x = (evt.clientX || 0) + 10;
     const y = (evt.clientY || 0) + 10;
-    calibrationTooltip.style.left = `${x}px`;
-    calibrationTooltip.style.top = `${y}px`;
-    calibrationTooltip.innerHTML = `Sample Size: ${sampleSize}<br>Declared: ${declared}%<br>Actual: ${Math.round(actual)}%`;
-    calibrationTooltip.style.display = 'block';
+    tooltip.style.left = `${x}px`;
+    tooltip.style.top = `${y}px`;
+    tooltip.innerHTML = `Sample Size: ${sampleSize}<br>Declared: ${declared}%<br>Actual: ${Math.round(actual)}%`;
+    tooltip.style.display = 'block';
 }
 
-function hideCalibrationTooltip() {
-    if (calibrationTooltip) calibrationTooltip.style.display = 'none';
+function hideCalibrationTooltip(group) {
+    if (group) {
+        const tooltip = calibrationTooltips.get(group);
+        if (tooltip) tooltip.style.display = 'none';
+        return;
+    }
+    calibrationTooltips.forEach(el => {
+        el.style.display = 'none';
+    });
+}
+
+function isFirstGuessOnlyEnabled() {
+    if (!firstGuessCheckboxes || firstGuessCheckboxes.length === 0) return false;
+    return firstGuessCheckboxes[0].checked;
 }
 
 function updateCalibrationChart() {
-    const svg = calibrationChart;
-    if (!svg) return;
+    if (!calibrationCharts || calibrationCharts.length === 0) return;
 
-    hideCalibrationTooltip();
-    while (svg.firstChild) svg.removeChild(svg.firstChild);
-
-    const width = svg.viewBox.baseVal?.width || svg.width.baseVal.value || 300;
-    const height = svg.viewBox.baseVal?.height || svg.height.baseVal.value || 200;
-    svg.setAttribute('overflow', 'visible');
-
-    const firstOnly = firstGuessCheckbox && firstGuessCheckbox.checked;
+    const firstOnly = isFirstGuessOnlyEnabled();
     let data = stats.calibrationData || [];
     if (firstOnly) {
         data = data.filter(d => d.guessNumber === 1);
@@ -2184,112 +2254,119 @@ function updateCalibrationChart() {
         }
     });
 
-    const paddingLeft = 50,
-        paddingBottom = 60,
-        paddingTop = 20,
-        paddingRight = 20;
-    const plotWidth = width - paddingLeft - paddingRight;
-    const plotHeight = height - paddingTop - paddingBottom;
-
+    const hasData = bins.some(bin => bin.total > 0);
     const ns = 'http://www.w3.org/2000/svg';
 
-    const hasData = bins.some(bin => bin.total > 0);
-    if (calibrationNote) {
-        calibrationNote.style.display = hasData ? 'none' : 'block';
-    }
+    calibrationCharts.forEach(svg => {
+        if (!svg) return;
+        const group = svg.dataset.calibrationChart || 'default';
+        hideCalibrationTooltip(group);
+        while (svg.firstChild) svg.removeChild(svg.firstChild);
 
-    // Axes
-    const xAxis = document.createElementNS(ns, 'line');
-    xAxis.setAttribute('x1', paddingLeft);
-    xAxis.setAttribute('y1', height - paddingBottom);
-    xAxis.setAttribute('x2', width - paddingRight);
-    xAxis.setAttribute('y2', height - paddingBottom);
-    xAxis.setAttribute('stroke', '#ccc');
-    svg.appendChild(xAxis);
+        const width = svg.viewBox.baseVal?.width || svg.width.baseVal.value || 300;
+        const height = svg.viewBox.baseVal?.height || svg.height.baseVal.value || 200;
+        svg.setAttribute('overflow', 'visible');
 
-    const yAxis = document.createElementNS(ns, 'line');
-    yAxis.setAttribute('x1', paddingLeft);
-    yAxis.setAttribute('y1', height - paddingBottom);
-    yAxis.setAttribute('x2', paddingLeft);
-    yAxis.setAttribute('y2', paddingTop);
-    yAxis.setAttribute('stroke', '#ccc');
-    svg.appendChild(yAxis);
+        const note = calibrationNotes.get(group);
+        if (note) {
+            note.style.display = hasData ? 'none' : 'block';
+        }
 
-    // Diagonal line
-    const diag = document.createElementNS(ns, 'line');
-    diag.setAttribute('x1', paddingLeft);
-    diag.setAttribute('y1', height - paddingBottom);
-    diag.setAttribute('x2', width - paddingRight);
-    diag.setAttribute('y2', paddingTop);
-    diag.setAttribute('stroke', '#eee');
-    svg.appendChild(diag);
+        const paddingLeft = 50;
+        const paddingBottom = 60;
+        const paddingTop = 20;
+        const paddingRight = 20;
+        const plotWidth = width - paddingLeft - paddingRight;
+        const plotHeight = height - paddingTop - paddingBottom;
 
-    // Ticks and labels
-    const xTickValues = declaredLevels;
-    xTickValues.forEach((value) => {
-        const x = paddingLeft + (value / 100) * plotWidth;
+        const xAxis = document.createElementNS(ns, 'line');
+        xAxis.setAttribute('x1', paddingLeft);
+        xAxis.setAttribute('y1', height - paddingBottom);
+        xAxis.setAttribute('x2', width - paddingRight);
+        xAxis.setAttribute('y2', height - paddingBottom);
+        xAxis.setAttribute('stroke', '#ccc');
+        svg.appendChild(xAxis);
 
-        const xTick = document.createElementNS(ns, 'line');
-        xTick.setAttribute('x1', x);
-        xTick.setAttribute('y1', height - paddingBottom);
-        xTick.setAttribute('x2', x);
-        xTick.setAttribute('y2', height - paddingBottom + 5);
-        xTick.setAttribute('stroke', '#ccc');
-        svg.appendChild(xTick);
+        const yAxis = document.createElementNS(ns, 'line');
+        yAxis.setAttribute('x1', paddingLeft);
+        yAxis.setAttribute('y1', height - paddingBottom);
+        yAxis.setAttribute('x2', paddingLeft);
+        yAxis.setAttribute('y2', paddingTop);
+        yAxis.setAttribute('stroke', '#ccc');
+        svg.appendChild(yAxis);
 
-        const xLabel = document.createElementNS(ns, 'text');
-        xLabel.setAttribute('x', x + 2);
-        xLabel.setAttribute('y', height - paddingBottom + 20);
-        xLabel.setAttribute('text-anchor', 'end');
-        xLabel.setAttribute('font-size', '10');
-        xLabel.setAttribute('transform', `rotate(-45 ${x} ${height - paddingBottom + 15})`);
-        xLabel.textContent = `${value}%`;
-        svg.appendChild(xLabel);
-    });
+        const diag = document.createElementNS(ns, 'line');
+        diag.setAttribute('x1', paddingLeft);
+        diag.setAttribute('y1', height - paddingBottom);
+        diag.setAttribute('x2', width - paddingRight);
+        diag.setAttribute('y2', paddingTop);
+        diag.setAttribute('stroke', '#eee');
+        svg.appendChild(diag);
 
-    const yTickValues = Array.from(new Set([...declaredLevels, 100]))
-        .filter((value) => value !== MAX_CONFIDENCE_PERCENT)
-        .sort((a, b) => a - b);
-    yTickValues.forEach((value) => {
-        const y = height - paddingBottom - (value / 100) * plotHeight;
+        declaredLevels.forEach((value) => {
+            const x = paddingLeft + (value / 100) * plotWidth;
 
-        const yTick = document.createElementNS(ns, 'line');
-        yTick.setAttribute('x1', paddingLeft - 5);
-        yTick.setAttribute('y1', y);
-        yTick.setAttribute('x2', paddingLeft);
-        yTick.setAttribute('y2', y);
-        yTick.setAttribute('stroke', '#ccc');
-        svg.appendChild(yTick);
+            const xTick = document.createElementNS(ns, 'line');
+            xTick.setAttribute('x1', x);
+            xTick.setAttribute('y1', height - paddingBottom);
+            xTick.setAttribute('x2', x);
+            xTick.setAttribute('y2', height - paddingBottom + 5);
+            xTick.setAttribute('stroke', '#ccc');
+            svg.appendChild(xTick);
 
-        const yLabel = document.createElementNS(ns, 'text');
-        yLabel.setAttribute('x', paddingLeft - 8);
-        yLabel.setAttribute('y', y + 6);
-        yLabel.setAttribute('text-anchor', 'end');
-        yLabel.setAttribute('font-size', '10');
-        yLabel.textContent = `${value}%`;
-        svg.appendChild(yLabel);
-    });
+            const xLabel = document.createElementNS(ns, 'text');
+            xLabel.setAttribute('x', x + 2);
+            xLabel.setAttribute('y', height - paddingBottom + 20);
+            xLabel.setAttribute('text-anchor', 'end');
+            xLabel.setAttribute('font-size', '10');
+            xLabel.setAttribute('transform', `rotate(-45 ${x} ${height - paddingBottom + 15})`);
+            xLabel.textContent = `${value}%`;
+            svg.appendChild(xLabel);
+        });
 
-    // Calibration points
-    bins.forEach((bin, i) => {
-        if (!bin.total) return;
-        const x = paddingLeft + (declaredLevels[i] / 100) * plotWidth;
-        const ratio = bin.correct / bin.total;
-        const y = height - paddingBottom - ratio * plotHeight;
-        const circle = document.createElementNS(ns, 'circle');
-        circle.setAttribute('cx', x);
-        circle.setAttribute('cy', y);
-        circle.setAttribute('r', 3);
-        circle.setAttribute('fill', '#3498db');
-        const declaredPercent = declaredLevels[i];
-        circle.addEventListener('mouseenter', (e) => showCalibrationTooltip(e, bin.total, declaredPercent, ratio * 100));
-        circle.addEventListener('mouseleave', hideCalibrationTooltip);
-        circle.addEventListener('click', (e) => showCalibrationTooltip(e, bin.total, declaredPercent, ratio * 100));
-        circle.addEventListener('touchstart', (e) => {
-            const t = e.touches[0];
-            if (t) showCalibrationTooltip(t, bin.total, declaredPercent, ratio * 100);
-        }, { passive: true });
-        svg.appendChild(circle);
+        const yTickValues = Array.from(new Set([...declaredLevels, 100]))
+            .filter((value) => value !== MAX_CONFIDENCE_PERCENT)
+            .sort((a, b) => a - b);
+        yTickValues.forEach((value) => {
+            const y = height - paddingBottom - (value / 100) * plotHeight;
+
+            const yTick = document.createElementNS(ns, 'line');
+            yTick.setAttribute('x1', paddingLeft - 5);
+            yTick.setAttribute('y1', y);
+            yTick.setAttribute('x2', paddingLeft);
+            yTick.setAttribute('y2', y);
+            yTick.setAttribute('stroke', '#ccc');
+            svg.appendChild(yTick);
+
+            const yLabel = document.createElementNS(ns, 'text');
+            yLabel.setAttribute('x', paddingLeft - 8);
+            yLabel.setAttribute('y', y + 6);
+            yLabel.setAttribute('text-anchor', 'end');
+            yLabel.setAttribute('font-size', '10');
+            yLabel.textContent = `${value}%`;
+            svg.appendChild(yLabel);
+        });
+
+        bins.forEach((bin, i) => {
+            if (!bin.total) return;
+            const x = paddingLeft + (declaredLevels[i] / 100) * plotWidth;
+            const ratio = bin.correct / bin.total;
+            const y = height - paddingBottom - ratio * plotHeight;
+            const circle = document.createElementNS(ns, 'circle');
+            circle.setAttribute('cx', x);
+            circle.setAttribute('cy', y);
+            circle.setAttribute('r', 3);
+            circle.setAttribute('fill', '#3498db');
+            const declaredPercent = declaredLevels[i];
+            circle.addEventListener('mouseenter', (e) => showCalibrationTooltip(e, bin.total, declaredPercent, ratio * 100, group));
+            circle.addEventListener('mouseleave', () => hideCalibrationTooltip(group));
+            circle.addEventListener('click', (e) => showCalibrationTooltip(e, bin.total, declaredPercent, ratio * 100, group));
+            circle.addEventListener('touchstart', (e) => {
+                const t = e.touches[0];
+                if (t) showCalibrationTooltip(t, bin.total, declaredPercent, ratio * 100, group);
+            }, { passive: true });
+            svg.appendChild(circle);
+        });
     });
 }
 
@@ -2417,8 +2494,11 @@ function loadCalibrationSetting() {
         cb.checked = calibrationEnabled;
     });
     const savedFirstOnly = localStorage.getItem('fermiFirstGuessOnly');
-    if (firstGuessCheckbox && savedFirstOnly !== null) {
-        firstGuessCheckbox.checked = savedFirstOnly === 'true';
+    if (savedFirstOnly !== null) {
+        const checked = savedFirstOnly === 'true';
+        firstGuessCheckboxes.forEach(cb => {
+            cb.checked = checked;
+        });
     }
     updateConfidenceInputVisibility();
     updateCalibrationChart();
@@ -2434,7 +2514,7 @@ function setCalibrationEnabled(enabled) {
 }
 
 function updateConfidenceInputVisibility() {
-    const firstOnlyActive = firstGuessCheckbox && firstGuessCheckbox.checked;
+    const firstOnlyActive = isFirstGuessOnlyEnabled();
     const showConfidence = calibrationEnabled && (!firstOnlyActive || currentGuess === 0);
 
     if (confidenceWrapper) {
@@ -3157,6 +3237,14 @@ function parseURL() {
         return { view: 'calendar' };
     }
 
+    if (hash === '#/help') {
+        return { view: 'help' };
+    }
+
+    if (hash === '#/stats') {
+        return { view: 'stats' };
+    }
+
     const questionMatch = hash.match(/^#\/(\d{4}-\d{2}-\d{2})$/);
     if (questionMatch) {
         return { view: 'game', date: questionMatch[1] };
@@ -3214,7 +3302,17 @@ function handlePopState() {
     const route = parseURL();
 
     if (route.view === 'calendar') {
-        setActiveView('calendar', { skipURLUpdate: true, force: true });
+        setActiveView('calendar', { skipURLUpdate: true, force: true, fromHistory: true });
+        return;
+    }
+
+    if (route.view === 'help') {
+        setActiveView('help', { skipURLUpdate: true, force: true, fromHistory: true });
+        return;
+    }
+
+    if (route.view === 'stats') {
+        setActiveView('stats', { skipURLUpdate: true, force: true, fromHistory: true });
         return;
     }
 
@@ -3225,7 +3323,7 @@ function handlePopState() {
         return;
     }
 
-    setActiveView('welcome', { skipURLUpdate: true, force: true });
+    setActiveView('welcome', { skipURLUpdate: true, force: true, fromHistory: true });
 }
 
 // Initialize routing
@@ -3242,6 +3340,10 @@ function initRouting(skipInitialNavigation = false) {
     const route = parseURL();
     if (route.view === 'calendar') {
         setActiveView('calendar', { skipURLUpdate: true, force: true });
+    } else if (route.view === 'help') {
+        setActiveView('help', { skipURLUpdate: true, force: true, fromHistory: true });
+    } else if (route.view === 'stats') {
+        setActiveView('stats', { skipURLUpdate: true, force: true, fromHistory: true });
     } else if (route.view === 'game' && route.date) {
         if (!navigateToQuestion(route.date)) {
             navigateToCurrentQuestion();
@@ -3316,6 +3418,24 @@ function setupEventListeners() {
         });
     }
 
+    if (helpBackBtn) {
+        helpBackBtn.addEventListener('click', () => {
+            navigateBack('welcome');
+        });
+    }
+
+    if (statsBackBtn) {
+        statsBackBtn.addEventListener('click', () => {
+            navigateBack('welcome');
+        });
+    }
+
+    if (calendarBackBtn) {
+        calendarBackBtn.addEventListener('click', () => {
+            navigateBack('welcome');
+        });
+    }
+
     // Help button
     helpBtn.addEventListener('click', showHelp);
 
@@ -3352,11 +3472,19 @@ function setupEventListeners() {
         });
     }
 
-    if (firstGuessCheckbox) {
-        firstGuessCheckbox.addEventListener('change', () => {
-            localStorage.setItem('fermiFirstGuessOnly', firstGuessCheckbox.checked ? 'true' : 'false');
-            updateCalibrationChart();
-            updateConfidenceInputVisibility();
+    if (firstGuessCheckboxes.length) {
+        firstGuessCheckboxes.forEach(cb => {
+            cb.addEventListener('change', () => {
+                const checked = cb.checked;
+                firstGuessCheckboxes.forEach(other => {
+                    if (other !== cb) {
+                        other.checked = checked;
+                    }
+                });
+                localStorage.setItem('fermiFirstGuessOnly', checked ? 'true' : 'false');
+                updateCalibrationChart();
+                updateConfidenceInputVisibility();
+            });
         });
     }
 
@@ -3433,7 +3561,9 @@ function setupEventListeners() {
                     sourceText.textContent = explanation;
                 }
                 // Reset stats placeholders before fetching
-                if (medianFirstGuessText) medianFirstGuessText.textContent = '';
+                medianFirstGuessElements.forEach(el => {
+                    el.textContent = '';
+                });
                 const playersEl = document.getElementById('source-players-count');
                 const winRateEl = document.getElementById('source-win-rate');
                 const avgTriesEl = document.getElementById('source-avg-tries');
@@ -3444,18 +3574,24 @@ function setupEventListeners() {
                 // Fetch median first guess
                 fetchMedianFirstGuess(currentQuestion.date)
                     .then(median => {
-                        if (median != null && medianFirstGuessText) {
-                            medianFirstGuessText.textContent = `The median first guess was ${formatNumber(median)}`;
+                        if (median != null) {
+                            medianFirstGuessElements.forEach(el => {
+                                el.textContent = `The median first guess was ${formatNumber(median)}`;
+                            });
                         }
                     })
                     .catch(() => {/* ignore */});
 
                 // Fetch user's first-guess percentile
-                if (firstGuessPercentileText) firstGuessPercentileText.textContent = '';
+                firstGuessPercentileElements.forEach(el => {
+                    el.textContent = '';
+                });
                 fetchFirstGuessPercentile(currentQuestion.date)
                     .then(p => {
-                        if (typeof p === 'number' && firstGuessPercentileText) {
-                            firstGuessPercentileText.textContent = `Your first guess is in the ${p}th percentile, meaning you've performed as well or better than ${p}% of players.`;
+                        if (typeof p === 'number') {
+                            firstGuessPercentileElements.forEach(el => {
+                                el.textContent = `Your first guess is in the ${p}th percentile, meaning you've performed as well or better than ${p}% of players.`;
+                            });
                         }
                     })
                     .catch(() => {/* ignore */});
@@ -3516,7 +3652,7 @@ function setupEventListeners() {
 
     // Share buttons
     shareBtn.addEventListener('click', shareGame);
-    shareStatsBtn.addEventListener('click', shareStats);
+    shareStatsButtons.forEach(btn => btn.addEventListener('click', shareStats));
         
     // Close modals when clicking outside (desktop + mobile)
     [helpModal, statsModal, questionsModal, sourceModal].forEach(modal => {
@@ -3538,12 +3674,13 @@ function setupEventListeners() {
     }
 }
 
-if (calibrationChart) {
-    calibrationChart.addEventListener('mouseleave', hideCalibrationTooltip);
-}
+calibrationCharts.forEach(chart => {
+    const group = chart.dataset.calibrationChart || 'default';
+    chart.addEventListener('mouseleave', () => hideCalibrationTooltip(group));
+});
 
 document.addEventListener('click', (e) => {
-    if (!e.target.closest('#calibration-chart')) hideCalibrationTooltip();
+    if (!e.target.closest('[data-calibration-chart]')) hideCalibrationTooltip();
 });
 
 // Initialize the game when the page loads

--- a/styles.css
+++ b/styles.css
@@ -34,6 +34,70 @@ main {
     display: block;
 }
 
+.info-view-card {
+    max-width: 900px;
+    margin: 40px auto;
+    background: rgba(255, 255, 255, 0.97);
+    border: 2px solid #e9ecef;
+    border-radius: 22px;
+    padding: 28px 32px 36px;
+    box-shadow: 0 18px 35px rgba(15, 23, 42, 0.08);
+}
+
+.view-header {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 18px;
+}
+
+.view-header h2 {
+    font-size: 1rem;
+    margin-bottom: 0;
+}
+
+.view-body {
+    font-size: 0.8rem;
+}
+
+.back-button {
+    background: none;
+    border: none;
+    color: #2563eb;
+    font-family: 'Press Start 2P', monospace;
+    font-size: 0.7rem;
+    cursor: pointer;
+    padding: 10px 12px;
+    border-radius: 10px;
+    transition: background-color 0.2s, color 0.2s;
+}
+
+.back-button:hover,
+.back-button:focus-visible {
+    background-color: rgba(37, 99, 235, 0.1);
+    color: #1d4ed8;
+    outline: none;
+}
+
+#help-view .accordion,
+#stats-view .accordion {
+    max-height: none;
+}
+
+.calendar-header {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    justify-content: flex-start;
+    margin-bottom: 12px;
+}
+
+.calendar-header .calendar-title {
+    flex: 1;
+    text-align: left;
+    margin-bottom: 0;
+}
+
 .game-container {
     max-width: 500px;
     margin: 0 auto;
@@ -1490,6 +1554,31 @@ button.calendar-cell:disabled {
 }
 
 @media (max-width: 768px) {
+    .info-view-card {
+        margin: 24px 0;
+        padding: 24px 18px 32px;
+    }
+
+    .view-header {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 8px;
+    }
+
+    .back-button {
+        padding-left: 0;
+    }
+
+    .calendar-header {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 8px;
+    }
+
+    .calendar-header .calendar-title {
+        text-align: left;
+    }
+
     .welcome-content {
         margin: 32px auto;
         padding: 28px 22px;


### PR DESCRIPTION
## Summary
- add dedicated How to Play and Statistics views that mirror the modal content and include back navigation
- track view history in the client to support back buttons and reuse stats content in multiple contexts
- update styling and the calendar layout to accommodate new view containers and back actions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cd1889779883299bb20f0689fd29aa