### PR TITLE
Convert modal overlays to navigable views

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,6 +66,9 @@
 
         <section id="game-view" class="view">
             <div class="game-container">
+                <div class="view-header game-view-header">
+                    <button type="button" class="back-button" id="game-back-btn">&lt; Back</button>
+                </div>
         <!-- Question Display -->
         <div class="question-container">
             <div class="question-box">

--- a/index.html
+++ b/index.html
@@ -48,7 +48,19 @@
                     </div>
                     <div class="daily-challenge-actions">
                         <button id="play-daily-btn" class="primary-action">Play</button>
-                        <button id="calendar-link-btn" class="secondary-action">Browse the calendar</button>
+                        <button id="calendar-link-btn" class="secondary-action">Previous days</button>
+                    </div>
+                </div>
+                <div class="welcome-info-card">
+                    <div class="daily-challenge-header">
+                        <h3>How to Play</h3>
+                    </div>
+                    <div class="welcome-info-body">
+                        <p class="daily-challenge-question welcome-info-lede">Fermi estimates. Probability calibration training. Bayesian updating.</p>
+                        <p class="welcome-info-note">Many daunting terms, but this game effectively trains some of the core rationality techniques.</p>
+                    </div>
+                    <div class="welcome-info-actions">
+                        <button id="learn-more-btn" class="secondary-action">Learn more</button>
                     </div>
                 </div>
             </div>

--- a/index.html
+++ b/index.html
@@ -59,9 +59,7 @@
                         <p class="daily-challenge-question welcome-info-lede">Fermi estimates. Probability calibration training. Bayesian updating.</p>
                         <p class="welcome-info-note">Many daunting terms, but this game effectively trains some of the core rationality techniques.</p>
                     </div>
-                    <div class="welcome-info-actions">
-                        <button id="learn-more-btn" class="secondary-action">Learn more</button>
-                    </div>
+                    <button id="learn-more-btn" class="secondary-action">Learn more</button>
                 </div>
             </div>
         </section>

--- a/index.html
+++ b/index.html
@@ -35,15 +35,12 @@
     <main>
         <section id="welcome-screen" class="view active">
             <div class="welcome-content">
-                <div class="daily-challenge-card">
+                <div class="daily-challenge-card" id="daily-challenge-card">
+                    <span id="daily-challenge-date" class="daily-challenge-date-badge"></span>
                     <div class="daily-challenge-header">
                         <h3>Daily Challenge</h3>
-                        <span id="daily-challenge-date" class="daily-challenge-date"></span>
                     </div>
                     <div class="daily-challenge-body">
-                        <div class="daily-challenge-image" id="daily-challenge-image-container" style="display: none;">
-                            <img id="daily-challenge-image" alt="" />
-                        </div>
                         <div class="daily-challenge-text">
                             <p id="daily-challenge-question" class="daily-challenge-question"></p>
                             <p id="daily-challenge-status" class="daily-challenge-status"></p>

--- a/index.html
+++ b/index.html
@@ -67,7 +67,7 @@
         <section id="game-view" class="view">
             <div class="game-container">
                 <div class="view-header game-view-header">
-                    <button type="button" class="back-button" id="game-back-btn">&lt; Back</button>
+                    <button type="button" class="back-button" id="game-back-btn">Back</button>
                 </div>
         <!-- Question Display -->
         <div class="question-container">

--- a/index.html
+++ b/index.html
@@ -35,8 +35,6 @@
     <main>
         <section id="welcome-screen" class="view active">
             <div class="welcome-content">
-                <h2 class="welcome-title">Welcome to Fermi Questions</h2>
-                <p class="welcome-subtitle">Sharpen your estimation skills with a fresh puzzle every day.</p>
                 <div class="daily-challenge-card">
                     <div class="daily-challenge-header">
                         <h3>Daily Challenge</h3>
@@ -51,9 +49,11 @@
                             <p id="daily-challenge-status" class="daily-challenge-status"></p>
                         </div>
                     </div>
-                    <button id="play-daily-btn" class="primary-action">Play</button>
+                    <div class="daily-challenge-actions">
+                        <button id="play-daily-btn" class="primary-action">Play</button>
+                        <button id="calendar-link-btn" class="secondary-action">Browse the calendar</button>
+                    </div>
                 </div>
-                <button id="calendar-link-btn" class="secondary-action">Browse the calendar</button>
             </div>
         </section>
 

--- a/index.html
+++ b/index.html
@@ -215,12 +215,6 @@
                     <button type="button" class="back-button" id="calendar-back-btn">&lt; Back</button>
                     <h2 class="calendar-title">Question Calendar</h2>
                 </div>
-                <p class="calendar-subtitle">Pick a day to play or review its challenge.</p>
-                <div class="calendar-legend">
-                    <span><span class="legend-box pending"></span> Not played</span>
-                    <span><span class="legend-box won"></span> Completed</span>
-                    <span><span class="legend-box lost"></span> Missed</span>
-                </div>
                 <div id="calendar-months" class="calendar-months"></div>
             </div>
         </section>

--- a/index.html
+++ b/index.html
@@ -88,19 +88,6 @@
             </div>
         </div>
 
-        <!-- Comments Section -->
-        <div class="comments-section" id="comments-section">
-            <div class="comments-header">
-                <button class="icon-button" id="comments-back-btn">&lt;</button>
-                <h2>Comments</h2>
-            </div>
-            <div class="comments-list" id="comments-list"></div>
-            <div class="comments-input">
-                <textarea id="comment-input" placeholder="Add a comment..."></textarea>
-                <button id="comment-submit-btn" class="submit-btn">Post</button>
-            </div>
-        </div>
-
         <!-- Questions History Modal -->
         <div class="modal" id="questions-modal">
             <div class="modal-content">
@@ -209,10 +196,31 @@
             </div>
         </div>
 
-        <!-- Help Modal -->
-        <div class="modal" id="help-modal">
-            <div class="modal-content">
-                <h2>How to Play</h2>
+            </div>
+        </section>
+
+        <section id="calendar-view" class="view">
+            <div class="calendar-wrapper">
+                <div class="view-header">
+                    <button type="button" class="back-button" id="calendar-back-btn">&lt; Back</button>
+                    <h2 class="calendar-title">Question Calendar</h2>
+                </div>
+                <p class="calendar-subtitle">Pick a day to play or review its challenge.</p>
+                <div class="calendar-legend">
+                    <span><span class="legend-box pending"></span> Not played</span>
+                    <span><span class="legend-box won"></span> Completed</span>
+                    <span><span class="legend-box lost"></span> Missed</span>
+                </div>
+                <div id="calendar-months" class="calendar-months"></div>
+            </div>
+        </section>
+
+        <section id="help-view" class="view">
+            <div class="info-view">
+                <div class="view-header">
+                    <button type="button" class="back-button" id="help-back-btn">&lt; Back</button>
+                    <h2>How to Play</h2>
+                </div>
                 <div class="accordion" id="help-accordion">
                     <div class="accordion-item" id="acc-calibration-help-item">
                         <button class="accordion-header" id="acc-calibration-help-header" aria-expanded="false" aria-controls="acc-calibration-help-panel">
@@ -249,15 +257,15 @@
                         </div>
                     </div>
                 </div>
-                <button id="close-help-btn" class="close-btn">Close</button>
             </div>
-        </div>
+        </section>
 
-
-        <!-- Source/Explanation Modal -->
-        <div class="modal" id="source-modal">
-            <div class="modal-content">
-                <h2>Source & Stats</h2>
+        <section id="source-view" class="view">
+            <div class="info-view">
+                <div class="view-header">
+                    <button type="button" class="back-button" id="source-back-btn">&lt; Back</button>
+                    <h2>Source & Stats</h2>
+                </div>
                 <div class="accordion" id="source-accordion">
                     <div class="accordion-item" id="acc-source-item">
                         <button class="accordion-header" id="acc-source-header" aria-expanded="false" aria-controls="acc-source-panel">
@@ -303,14 +311,15 @@
                         </div>
                     </div>
                 </div>
-                <button id="close-source-btn" class="close-btn">Close</button>
             </div>
-        </div>
+        </section>
 
-        <!-- Stats Modal -->
-        <div class="modal" id="stats-modal">
-            <div class="modal-content">
-                <h2>Statistics</h2>
+        <section id="stats-view" class="view">
+            <div class="info-view">
+                <div class="view-header">
+                    <button type="button" class="back-button" id="stats-back-btn">&lt; Back</button>
+                    <h2>Statistics</h2>
+                </div>
                 <div class="accordion" id="stats-accordion">
                     <div class="accordion-item open" id="acc-statsgrid-item">
                         <button class="accordion-header" id="acc-statsgrid-header" aria-expanded="true" aria-controls="acc-statsgrid-panel">
@@ -425,22 +434,20 @@
                 </div>
 
                 <button id="share-stats-btn" class="share-btn">Share</button>
-                <button id="close-stats-btn" class="close-btn">Close</button>
-            </div>
-        </div>
             </div>
         </section>
 
-        <section id="calendar-view" class="view">
-            <div class="calendar-wrapper">
-                <h2 class="calendar-title">Question Calendar</h2>
-                <p class="calendar-subtitle">Pick a day to play or review its challenge.</p>
-                <div class="calendar-legend">
-                    <span><span class="legend-box pending"></span> Not played</span>
-                    <span><span class="legend-box won"></span> Completed</span>
-                    <span><span class="legend-box lost"></span> Missed</span>
+        <section id="comments-section" class="view comments-section">
+            <div class="info-view comments-view">
+                <div class="view-header">
+                    <button type="button" class="back-button" id="comments-back-btn">&lt; Back</button>
+                    <h2>Comments</h2>
                 </div>
-                <div id="calendar-months" class="calendar-months"></div>
+                <div class="comments-list" id="comments-list"></div>
+                <div class="comments-input">
+                    <textarea id="comment-input" placeholder="Add a comment..."></textarea>
+                    <button id="comment-submit-btn" class="submit-btn">Post</button>
+                </div>
             </div>
         </section>
     </main>

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
     <meta name="description" content="A Wordle-style game for Fermi questions. Guess the answer to estimation questions in 6 or less tries.">
     <link rel="canonical" href="https://www.fermiquestions.org">
     <link rel="stylesheet" href="styles.css">
-    <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Nunito:ital,wght@0,200..1000;1,200..1000&family=Open+Sans:wght@400;500&family=Varela+Round&display=swap" rel="stylesheet">
     <script defer data-domain="fermiquestions.org" data-api="https://fermiquestions.daniel-fetz.workers.dev/fermiquestions/event" src="https://fermiquestions.daniel-fetz.workers.dev/fermiquestions/script.hash.js"></script>
     <!-- Supabase client library -->
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>

--- a/script.js
+++ b/script.js
@@ -1666,7 +1666,10 @@ function renderCalendar() {
     calendarMonthsContainer.innerHTML = '';
     const dayLabels = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
 
-    questionsByMonth.forEach((monthQuestions, monthKey) => {
+    const monthEntries = Array.from(questionsByMonth.entries()).sort((a, b) => b[0].localeCompare(a[0]));
+
+    monthEntries.forEach(([monthKey, monthQuestions]) => {
+        const sortedMonthQuestions = [...monthQuestions].sort((a, b) => a.date.localeCompare(b.date));
         const monthContainer = document.createElement('div');
         monthContainer.className = 'calendar-month';
 
@@ -1686,7 +1689,7 @@ function renderCalendar() {
         });
 
         const questionByDay = new Map();
-        monthQuestions.forEach((question) => {
+        sortedMonthQuestions.forEach((question) => {
             const dayNumber = parseInt(question.date.slice(8, 10), 10);
             questionByDay.set(dayNumber, question);
         });

--- a/script.js
+++ b/script.js
@@ -1084,6 +1084,8 @@ const viewElements = {
     comments: commentsSection
 };
 
+const urlSyncedViews = new Set(['welcome', 'calendar', 'help', 'stats', 'source', 'comments']);
+
 
 // Confidence tooltip
 function initConfidenceTooltip() {
@@ -1132,15 +1134,39 @@ function initGame() {
 
     if (navigatedFromRoute) {
         setActiveView('game', { skipURLUpdate: true, force: true });
-    } else if (initialRoute.view === 'calendar') {
-        setActiveView('calendar', { skipURLUpdate: true, force: true });
-    } else if (initialRoute.view === 'game' && initialRoute.date) {
-        setActiveView('game', { skipURLUpdate: true, force: true });
-        if (currentQuestion) {
-            updateURL(currentQuestion.date);
-        }
     } else {
-        setActiveView('welcome', { force: true });
+        switch (initialRoute.view) {
+            case 'calendar':
+                setActiveView('calendar', { skipURLUpdate: true, force: true });
+                break;
+            case 'game':
+                if (initialRoute.date && currentQuestion) {
+                    setActiveView('game', { skipURLUpdate: true, force: true });
+                    updateURL(currentQuestion.date);
+                } else {
+                    navigateToCurrentQuestion();
+                }
+                break;
+            case 'help':
+                setActiveView('help', { skipURLUpdate: true, force: true });
+                break;
+            case 'stats':
+                updateStatsDisplay();
+                setActiveView('stats', { skipURLUpdate: true, force: true });
+                break;
+            case 'source':
+                prepareSourceView();
+                setActiveView('source', { skipURLUpdate: true, force: true });
+                break;
+            case 'comments':
+                void loadComments();
+                setActiveView('comments', { skipURLUpdate: true, force: true });
+                break;
+            case 'welcome':
+            default:
+                setActiveView('welcome', { force: true });
+                break;
+        }
     }
 
     setupEventListeners();
@@ -1424,6 +1450,14 @@ function setActiveView(view, options = {}) {
             updateHash('#/welcome');
         } else if (view === 'calendar') {
             updateHash('#/calendar');
+        } else if (view === 'help') {
+            updateHash('#/help');
+        } else if (view === 'stats') {
+            updateHash('#/stats');
+        } else if (view === 'source') {
+            updateHash('#/source');
+        } else if (view === 'comments') {
+            updateHash('#/comments');
         }
     }
 
@@ -1445,20 +1479,20 @@ function navigateToView(view, options = {}) {
     }
     const shouldSkipURL = skipURLUpdate !== undefined
         ? skipURLUpdate
-        : !['welcome', 'calendar'].includes(view);
+        : !urlSyncedViews.has(view);
     setActiveView(view, { skipURLUpdate: shouldSkipURL, force });
 }
 
 function goBack(fallbackView = 'welcome') {
     if (viewHistory.length > 0) {
         const previous = viewHistory.pop();
-        const skipURLUpdate = !['welcome', 'calendar'].includes(previous);
+        const skipURLUpdate = !urlSyncedViews.has(previous);
         setActiveView(previous, { skipURLUpdate, force: true });
         return;
     }
 
     if (fallbackView) {
-        const skipURLUpdate = !['welcome', 'calendar'].includes(fallbackView);
+        const skipURLUpdate = !urlSyncedViews.has(fallbackView);
         setActiveView(fallbackView, { skipURLUpdate, force: true });
     }
 }
@@ -2131,6 +2165,60 @@ function endGame() {
 function startNewGameFromModal() {
     gameOverModal.style.display = 'none';
     startNewGame();
+}
+
+function prepareSourceView() {
+    if (!sourceView || !currentQuestion || !sourceText) return;
+
+    const explanation = currentQuestion.explanation || 'No source available for this question as of now. This is a new feature that will be available in the coming days.';
+    sourceText.textContent = '';
+    const asHtml = /<a\s|https?:\/\//i.test(explanation);
+    if (asHtml) {
+        sourceText.innerHTML = explanation;
+    } else {
+        sourceText.textContent = explanation;
+    }
+
+    if (medianFirstGuessText) medianFirstGuessText.textContent = '';
+    const playersEl = document.getElementById('source-players-count');
+    const winRateEl = document.getElementById('source-win-rate');
+    const avgTriesEl = document.getElementById('source-avg-tries');
+    if (playersEl) playersEl.textContent = '0';
+    if (winRateEl) winRateEl.textContent = '0%';
+    if (avgTriesEl) avgTriesEl.textContent = '0';
+
+    fetchMedianFirstGuess(currentQuestion.date)
+        .then(median => {
+            if (median != null && medianFirstGuessText) {
+                medianFirstGuessText.textContent = `The median first guess was ${formatNumber(median)}`;
+            }
+        })
+        .catch(() => {/* ignore */});
+
+    if (firstGuessPercentileText) firstGuessPercentileText.textContent = '';
+    fetchFirstGuessPercentile(currentQuestion.date)
+        .then(percentile => {
+            if (typeof percentile === 'number' && firstGuessPercentileText) {
+                firstGuessPercentileText.textContent = `Your first guess is in the ${percentile}th percentile, meaning you've performed as well or better than ${percentile}% of players.`;
+            }
+        })
+        .catch(() => {/* ignore */});
+
+    fetchAverageGuesses(currentQuestion.date)
+        .then(avgData => {
+            if (!avgData) return;
+            if (playersEl && typeof avgData.totalPlayers === 'number') {
+                playersEl.textContent = `${avgData.totalPlayers}`;
+            }
+            if (winRateEl && typeof avgData.winRate === 'number') {
+                winRateEl.textContent = `${avgData.winRate}%`;
+            }
+            if (avgTriesEl && typeof avgData.average === 'number') {
+                const value = avgData.average;
+                avgTriesEl.textContent = Number.isInteger(value) ? `${value}` : value.toFixed(1);
+            }
+        })
+        .catch(() => {/* ignore */});
 }
 
 // Show help view
@@ -3218,6 +3306,22 @@ function parseURL() {
         return { view: 'calendar' };
     }
 
+    if (hash === '#/help') {
+        return { view: 'help' };
+    }
+
+    if (hash === '#/stats') {
+        return { view: 'stats' };
+    }
+
+    if (hash === '#/source') {
+        return { view: 'source' };
+    }
+
+    if (hash === '#/comments') {
+        return { view: 'comments' };
+    }
+
     const questionMatch = hash.match(/^#\/(\d{4}-\d{2}-\d{2})$/);
     if (questionMatch) {
         return { view: 'game', date: questionMatch[1] };
@@ -3274,16 +3378,38 @@ function navigateToCurrentQuestion() {
 function handlePopState() {
     const route = parseURL();
 
-    if (route.view === 'calendar') {
-        setActiveView('calendar', { skipURLUpdate: true, force: true });
-        return;
-    }
-
-    if (route.view === 'game' && route.date) {
-        if (!navigateToQuestion(route.date)) {
-            navigateToCurrentQuestion();
-        }
-        return;
+    switch (route.view) {
+        case 'calendar':
+            setActiveView('calendar', { skipURLUpdate: true, force: true });
+            return;
+        case 'help':
+            setActiveView('help', { skipURLUpdate: true, force: true });
+            return;
+        case 'stats':
+            updateStatsDisplay();
+            setActiveView('stats', { skipURLUpdate: true, force: true });
+            return;
+        case 'source':
+            prepareSourceView();
+            setActiveView('source', { skipURLUpdate: true, force: true });
+            return;
+        case 'comments':
+            void loadComments();
+            setActiveView('comments', { skipURLUpdate: true, force: true });
+            return;
+        case 'game':
+            if (route.date) {
+                if (!navigateToQuestion(route.date)) {
+                    navigateToCurrentQuestion();
+                }
+                return;
+            }
+            break;
+        case 'welcome':
+            setActiveView('welcome', { skipURLUpdate: true, force: true });
+            return;
+        default:
+            break;
     }
 
     setActiveView('welcome', { skipURLUpdate: true, force: true });
@@ -3301,14 +3427,34 @@ function initRouting(skipInitialNavigation = false) {
 
     // Handle initial page load
     const route = parseURL();
-    if (route.view === 'calendar') {
-        setActiveView('calendar', { skipURLUpdate: true, force: true });
-    } else if (route.view === 'game' && route.date) {
-        if (!navigateToQuestion(route.date)) {
-            navigateToCurrentQuestion();
-        }
-    } else {
-        setActiveView('welcome', { force: true });
+    switch (route.view) {
+        case 'calendar':
+            setActiveView('calendar', { skipURLUpdate: true, force: true });
+            break;
+        case 'game':
+            if (!route.date || !navigateToQuestion(route.date)) {
+                navigateToCurrentQuestion();
+            }
+            break;
+        case 'help':
+            setActiveView('help', { skipURLUpdate: true, force: true });
+            break;
+        case 'stats':
+            updateStatsDisplay();
+            setActiveView('stats', { skipURLUpdate: true, force: true });
+            break;
+        case 'source':
+            prepareSourceView();
+            setActiveView('source', { skipURLUpdate: true, force: true });
+            break;
+        case 'comments':
+            void loadComments();
+            setActiveView('comments', { skipURLUpdate: true, force: true });
+            break;
+        case 'welcome':
+        default:
+            setActiveView('welcome', { force: true });
+            break;
     }
 }
 
@@ -3487,61 +3633,7 @@ function setupEventListeners() {
     // Source button opens explanation view
     if (sourceBtn && sourceView) {
         sourceBtn.addEventListener('click', () => {
-            if (currentQuestion && sourceText) {
-                const explanation = currentQuestion.explanation || 'No source available for this question as of now. This is a new feature that will be available in the coming days.';
-                // Allow simple links if present; otherwise treat as plain text
-                sourceText.textContent = '';
-                const asHtml = /<a\s|https?:\/\//i.test(explanation);
-                if (asHtml) {
-                    sourceText.innerHTML = explanation;
-                } else {
-                    sourceText.textContent = explanation;
-                }
-                // Reset stats placeholders before fetching
-                if (medianFirstGuessText) medianFirstGuessText.textContent = '';
-                const playersEl = document.getElementById('source-players-count');
-                const winRateEl = document.getElementById('source-win-rate');
-                const avgTriesEl = document.getElementById('source-avg-tries');
-                if (playersEl) playersEl.textContent = '0';
-                if (winRateEl) winRateEl.textContent = '0%';
-                if (avgTriesEl) avgTriesEl.textContent = '0';
-
-                // Fetch median first guess
-                fetchMedianFirstGuess(currentQuestion.date)
-                    .then(median => {
-                        if (median != null && medianFirstGuessText) {
-                            medianFirstGuessText.textContent = `The median first guess was ${formatNumber(median)}`;
-                        }
-                    })
-                    .catch(() => {/* ignore */});
-
-                // Fetch user's first-guess percentile
-                if (firstGuessPercentileText) firstGuessPercentileText.textContent = '';
-                fetchFirstGuessPercentile(currentQuestion.date)
-                    .then(p => {
-                        if (typeof p === 'number' && firstGuessPercentileText) {
-                            firstGuessPercentileText.textContent = `Your first guess is in the ${p}th percentile, meaning you've performed as well or better than ${p}% of players.`;
-                        }
-                    })
-                    .catch(() => {/* ignore */});
-
-                // Fetch aggregate stats (players, win rate)
-                fetchAverageGuesses(currentQuestion.date)
-                    .then(avgData => {
-                        if (!avgData) return;
-                        if (playersEl && typeof avgData.totalPlayers === 'number') {
-                            playersEl.textContent = `${avgData.totalPlayers}`;
-                        }
-                        if (winRateEl && typeof avgData.winRate === 'number') {
-                            winRateEl.textContent = `${avgData.winRate}%`;
-                        }
-                        if (avgTriesEl && typeof avgData.average === 'number') {
-                            const v = avgData.average;
-                            avgTriesEl.textContent = Number.isInteger(v) ? `${v}` : v.toFixed(1);
-                        }
-                    })
-                    .catch(() => {/* ignore */});
-            }
+            prepareSourceView();
             navigateToView('source');
         });
     }

--- a/script.js
+++ b/script.js
@@ -1031,6 +1031,24 @@ const fermiQuestions = [
         hint: "January 1st, 2000 was a Saturday, which typically has 27% fewer births than weekdays.",
         date: "2025-09-24",
         image: "data:image/svg+xml;charset=UTF-8,%3csvg xmlns='http://www.w3.org/2000/svg' width='100' height='100' viewBox='0 0 100 100'%3e%3crect width='100' height='100' fill='%23f8fafc'/%3e%3ctext x='50' y='62' font-size='40' text-anchor='middle' fill='%23374151'%3e️👶%3c/text%3e%3c/svg%3e"
+    },
+    {
+        question: "How many transactions did Visa process per day in 2024?",
+        answer: 639000000,
+        category: "",
+        explanation: "",
+        hint: "Roughly 57% of all credit and debit cards outside China carry the Visa brand.",
+        date: "2025-09-25",
+        image: "data:image/svg+xml;charset=UTF-8,%3csvg xmlns='http://www.w3.org/2000/svg' width='100' height='100' viewBox='0 0 100 100'%3e%3crect width='100' height='100' fill='%23f8fafc'/%3e%3ctext x='50' y='62' font-size='40' text-anchor='middle' fill='%23374151'%3e️💳%3c/text%3e%3c/svg%3e"
+    },
+    {
+        question: "How many radiologists are there in the United States?",
+        answer: 31960,
+        category: "",
+        explanation: "",
+        hint: "In 2023, around 35.7 million MRI scans were performed in the US.",
+        date: "2025-09-26",
+        image: "data:image/svg+xml;charset=UTF-8,%3csvg xmlns='http://www.w3.org/2000/svg' width='100' height='100' viewBox='0 0 100 100'%3e%3crect width='100' height='100' fill='%23f8fafc'/%3e%3ctext x='50' y='62' font-size='40' text-anchor='middle' fill='%23374151'%3e️🩻%3c/text%3e%3c/svg%3e"
     }
 ];
 

--- a/script.js
+++ b/script.js
@@ -973,6 +973,15 @@ const fermiQuestions = [
         hint: "25.9M US households reported an income between $100,000 and $200,000 in 2022.",
         date: "2025-09-18",
         image: "data:image/svg+xml;charset=UTF-8,%3csvg xmlns='http://www.w3.org/2000/svg' width='100' height='100' viewBox='0 0 100 100'%3e%3crect width='100' height='100' fill='%23f8fafc'/%3e%3ctext x='50' y='62' font-size='40' text-anchor='middle' fill='%23374151'%3e️🇺🇸%3c/text%3e%3c/svg%3e"
+    },
+    {
+        question: "How many people work in McDonald's restaurants across the United States?",
+        answer: 800000,
+        category: "",
+        explanation: "",
+        hint: "There are 1,225 McDonald's restaurants in California.",
+        date: "2025-09-19",
+        image: "data:image/svg+xml;charset=UTF-8,%3csvg xmlns='http://www.w3.org/2000/svg' width='100' height='100' viewBox='0 0 100 100'%3e%3crect width='100' height='100' fill='%23f8fafc'/%3e%3ctext x='50' y='62' font-size='40' text-anchor='middle' fill='%23374151'%3e️🍔%3c/text%3e%3c/svg%3e"
     }
 ];
 

--- a/script.js
+++ b/script.js
@@ -1013,6 +1013,15 @@ const fermiQuestions = [
         hint: "Roughly 81% of the marriages formed in 2005 were still intact in 2015.",
         date: "2025-09-22",
         image: "data:image/svg+xml;charset=UTF-8,%3csvg xmlns='http://www.w3.org/2000/svg' width='100' height='100' viewBox='0 0 100 100'%3e%3crect width='100' height='100' fill='%23f8fafc'/%3e%3ctext x='50' y='62' font-size='40' text-anchor='middle' fill='%23374151'%3e️💔%3c/text%3e%3c/svg%3e"
+    },
+    {
+        question: "How many hours did the average journey from London to San Francisco take in 1900?",
+        answer: 293,
+        category: "",
+        explanation: "",
+        hint: "The straight-line distance between San Francisco and London is 5,354 miles (8,617 km).",
+        date: "2025-09-23",
+        image: "data:image/svg+xml;charset=UTF-8,%3csvg xmlns='http://www.w3.org/2000/svg' width='100' height='100' viewBox='0 0 100 100'%3e%3crect width='100' height='100' fill='%23f8fafc'/%3e%3ctext x='50' y='62' font-size='40' text-anchor='middle' fill='%23374151'%3e️🗽%3c/text%3e%3c/svg%3e"
     }
 ];
 

--- a/script.js
+++ b/script.js
@@ -1022,6 +1022,15 @@ const fermiQuestions = [
         hint: "The straight-line distance between San Francisco and London is 5,354 miles (8,617 km).",
         date: "2025-09-23",
         image: "data:image/svg+xml;charset=UTF-8,%3csvg xmlns='http://www.w3.org/2000/svg' width='100' height='100' viewBox='0 0 100 100'%3e%3crect width='100' height='100' fill='%23f8fafc'/%3e%3ctext x='50' y='62' font-size='40' text-anchor='middle' fill='%23374151'%3e️🗽%3c/text%3e%3c/svg%3e"
+    },
+    {
+        question: "How many babies were born in the United States on New Year's Day in 2000?",
+        answer: 9083,
+        category: "",
+        explanation: "",
+        hint: "January 1st, 2000 was a Saturday, which typically has 27% fewer births than weekdays.",
+        date: "2025-09-24",
+        image: "data:image/svg+xml;charset=UTF-8,%3csvg xmlns='http://www.w3.org/2000/svg' width='100' height='100' viewBox='0 0 100 100'%3e%3crect width='100' height='100' fill='%23f8fafc'/%3e%3ctext x='50' y='62' font-size='40' text-anchor='middle' fill='%23374151'%3e️👶%3c/text%3e%3c/svg%3e"
     }
 ];
 

--- a/script.js
+++ b/script.js
@@ -986,6 +986,33 @@ const fermiQuestions = [
         hint: "There are 1,225 McDonald's restaurants in California.",
         date: "2025-09-19",
         image: "data:image/svg+xml;charset=UTF-8,%3csvg xmlns='http://www.w3.org/2000/svg' width='100' height='100' viewBox='0 0 100 100'%3e%3crect width='100' height='100' fill='%23f8fafc'/%3e%3ctext x='50' y='62' font-size='40' text-anchor='middle' fill='%23374151'%3e️🍔%3c/text%3e%3c/svg%3e"
+    },
+    {
+        question: "How many daily active users did Duolingo have as of March 2025?",
+        answer: 46600000,
+        category: "",
+        explanation: "",
+        hint: "Duolingo's revenue in the first three months of 2025 was $230.7 million.",
+        date: "2025-09-20",
+        image: "data:image/svg+xml;charset=UTF-8,%3csvg xmlns='http://www.w3.org/2000/svg' width='100' height='100' viewBox='0 0 100 100'%3e%3crect width='100' height='100' fill='%23f8fafc'/%3e%3ctext x='50' y='62' font-size='40' text-anchor='middle' fill='%23374151'%3e️📱%3c/text%3e%3c/svg%3e"
+    },
+    {
+        question: "How many commercial airline pilots are employed worldwide?",
+        answer: 382000,
+        category: "",
+        explanation: "",
+        hint: "There were around 36.4 million scheduled commercial airline flights in 2024.",
+        date: "2025-09-21",
+        image: "data:image/svg+xml;charset=UTF-8,%3csvg xmlns='http://www.w3.org/2000/svg' width='100' height='100' viewBox='0 0 100 100'%3e%3crect width='100' height='100' fill='%23f8fafc'/%3e%3ctext x='50' y='62' font-size='40' text-anchor='middle' fill='%23374151'%3e️🧑‍✈️%3c/text%3e%3c/svg%3e"
+    },
+    {
+        question: "How many divorces took place in Germany in 2024?",
+        answer: 129337,
+        category: "",
+        explanation: "",
+        hint: "Roughly 81% of the marriages formed in 2005 were still intact in 2015.",
+        date: "2025-09-22",
+        image: "data:image/svg+xml;charset=UTF-8,%3csvg xmlns='http://www.w3.org/2000/svg' width='100' height='100' viewBox='0 0 100 100'%3e%3crect width='100' height='100' fill='%23f8fafc'/%3e%3ctext x='50' y='62' font-size='40' text-anchor='middle' fill='%23374151'%3e️💔%3c/text%3e%3c/svg%3e"
     }
 ];
 
@@ -1127,7 +1154,7 @@ function initGame() {
     let navigatedFromRoute = false;
 
     if (initialRoute.view === 'game' && initialRoute.date) {
-        navigatedFromRoute = navigateToQuestion(initialRoute.date);
+        navigatedFromRoute = navigateToQuestion(initialRoute.date, { skipHistory: true });
     }
 
     if (!navigatedFromRoute) {
@@ -1164,7 +1191,7 @@ function initGame() {
                 break;
             case 'source': {
                 const targetDate = initialRoute.date || (currentQuestion ? currentQuestion.date : null);
-                if (!ensureExtrasAccessible(targetDate)) {
+                if (!ensureExtrasAccessible(targetDate, { skipHistory: true })) {
                     break;
                 }
                 const resolvedDate = targetDate || (currentQuestion ? currentQuestion.date : null);
@@ -1178,7 +1205,7 @@ function initGame() {
             }
             case 'comments': {
                 const targetDate = initialRoute.date || (currentQuestion ? currentQuestion.date : null);
-                if (!ensureExtrasAccessible(targetDate)) {
+                if (!ensureExtrasAccessible(targetDate, { skipHistory: true })) {
                     break;
                 }
                 const resolvedDate = targetDate || (currentQuestion ? currentQuestion.date : null);
@@ -1537,7 +1564,7 @@ function navigateToView(view, options = {}) {
 
     if (view === 'source' || view === 'comments') {
         const targetDate = date || (currentQuestion ? currentQuestion.date : null);
-        if (!ensureExtrasAccessible(targetDate)) {
+        if (!ensureExtrasAccessible(targetDate, { skipHistory })) {
             return;
         }
     }
@@ -3463,14 +3490,16 @@ function hasCompletedQuestion(questionDate) {
     return Boolean(completedQuestions && completedQuestions[questionDate]);
 }
 
-function ensureExtrasAccessible(questionDate) {
+function ensureExtrasAccessible(questionDate, options = {}) {
+    const { skipHistory = false } = options;
+
     if (!questionDate) {
         navigateToCurrentQuestion();
         return false;
     }
 
     if (!hasCompletedQuestion(questionDate)) {
-        navigateToQuestion(questionDate);
+        navigateToQuestion(questionDate, { skipHistory });
         return false;
     }
 
@@ -3478,7 +3507,17 @@ function ensureExtrasAccessible(questionDate) {
 }
 
 // Navigate to a specific question by date
-function navigateToQuestion(questionDate) {
+function navigateToQuestion(questionDate, options = {}) {
+    const { skipHistory = false, sourceView } = options;
+    const previousView = sourceView !== undefined ? sourceView : currentView;
+
+    if (!skipHistory && previousView && previousView !== 'game') {
+        const lastEntry = viewHistory[viewHistory.length - 1];
+        if (lastEntry !== previousView) {
+            viewHistory.push(previousView);
+        }
+    }
+
     const question = getQuestionForDate(questionDate);
 
     if (question) {
@@ -3534,7 +3573,7 @@ function handlePopState() {
             return;
         case 'source': {
             const targetDate = route.date || (currentQuestion ? currentQuestion.date : null);
-            if (!ensureExtrasAccessible(targetDate)) {
+            if (!ensureExtrasAccessible(targetDate, { skipHistory: true })) {
                 return;
             }
             const resolvedDate = targetDate || (currentQuestion ? currentQuestion.date : null);
@@ -3548,7 +3587,7 @@ function handlePopState() {
         }
         case 'comments': {
             const targetDate = route.date || (currentQuestion ? currentQuestion.date : null);
-            if (!ensureExtrasAccessible(targetDate)) {
+            if (!ensureExtrasAccessible(targetDate, { skipHistory: true })) {
                 return;
             }
             const resolvedDate = targetDate || (currentQuestion ? currentQuestion.date : null);
@@ -3562,7 +3601,7 @@ function handlePopState() {
         }
         case 'game':
             if (route.date) {
-                if (!navigateToQuestion(route.date)) {
+                if (!navigateToQuestion(route.date, { skipHistory: true })) {
                     navigateToCurrentQuestion();
                 }
                 return;
@@ -3595,7 +3634,7 @@ function initRouting(skipInitialNavigation = false) {
             setActiveView('calendar', { skipURLUpdate: true, force: true });
             break;
         case 'game':
-            if (!route.date || !navigateToQuestion(route.date)) {
+            if (!route.date || !navigateToQuestion(route.date, { skipHistory: true })) {
                 navigateToCurrentQuestion();
             }
             break;
@@ -3608,7 +3647,7 @@ function initRouting(skipInitialNavigation = false) {
             break;
         case 'source': {
             const targetDate = route.date || (currentQuestion ? currentQuestion.date : null);
-            if (!ensureExtrasAccessible(targetDate)) {
+            if (!ensureExtrasAccessible(targetDate, { skipHistory: true })) {
                 break;
             }
             const resolvedDate = targetDate || (currentQuestion ? currentQuestion.date : null);
@@ -3622,7 +3661,7 @@ function initRouting(skipInitialNavigation = false) {
         }
         case 'comments': {
             const targetDate = route.date || (currentQuestion ? currentQuestion.date : null);
-            if (!ensureExtrasAccessible(targetDate)) {
+            if (!ensureExtrasAccessible(targetDate, { skipHistory: true })) {
                 break;
             }
             const resolvedDate = targetDate || (currentQuestion ? currentQuestion.date : null);

--- a/script.js
+++ b/script.js
@@ -441,6 +441,7 @@ let isNavigating = false;
 let currentView = 'welcome';
 let viewHistory = [];
 let todaysQuestion = null;
+let gameBackFallback = 'welcome';
 
 // Statistics
 let stats = {
@@ -992,6 +993,7 @@ const fermiQuestions = [
 const welcomeScreen = document.getElementById('welcome-screen');
 const gameView = document.getElementById('game-view');
 const calendarView = document.getElementById('calendar-view');
+const gameBackBtn = document.getElementById('game-back-btn');
 const playDailyBtn = document.getElementById('play-daily-btn');
 const calendarLinkBtn = document.getElementById('calendar-link-btn');
 const learnMoreBtn = document.getElementById('learn-more-btn');
@@ -1237,7 +1239,9 @@ function startNewGame(skipURLUpdate = false) {
         console.error('No questions available');
         return;
     }
-    
+
+    updateGameBackFallback(currentQuestion, currentView);
+
     // Check if this question already has saved progress
     const storageKey = `fermiGameState_${currentQuestion.date}`;
     const existingSavedState = localStorage.getItem(storageKey);
@@ -1303,6 +1307,21 @@ function getCurrentDate() {
     const month = String(today.getMonth() + 1).padStart(2, '0');
     const day = String(today.getDate()).padStart(2, '0');
     return `${year}-${month}-${day}`;
+}
+
+function updateGameBackFallback(question, sourceView = currentView) {
+    if (sourceView === 'calendar') {
+        gameBackFallback = 'calendar';
+        return;
+    }
+
+    if (question && question.date) {
+        const today = getCurrentDate();
+        gameBackFallback = question.date === today ? 'welcome' : 'calendar';
+        return;
+    }
+
+    gameBackFallback = 'welcome';
 }
 
 // Get question for a specific date
@@ -2777,6 +2796,7 @@ function loadCurrentGameState() {
             
             // Restore game state
             currentQuestion = gameState.question;
+            updateGameBackFallback(currentQuestion, currentView);
             currentGuess = gameState.currentGuess;
             gameWon = gameState.gameWon;
             gameOver = gameState.gameOver;
@@ -3075,6 +3095,8 @@ function updatePageTitle(question) {
 
 // Select a specific question
 function selectQuestion(question) {
+    updateGameBackFallback(question, currentView);
+
     // Save current game state before switching (if there's an active game)
     if (currentQuestion && currentGuess > 0 && !gameOver && !completedQuestions[currentQuestion.date]) {
         saveCurrentGameState();
@@ -3851,6 +3873,7 @@ function setupEventListeners() {
     });
 
     // Back buttons for secondary views
+    if (gameBackBtn) gameBackBtn.addEventListener('click', () => goBack(gameBackFallback));
     if (helpBackBtn) helpBackBtn.addEventListener('click', () => goBack('welcome'));
     if (statsBackBtn) statsBackBtn.addEventListener('click', () => goBack('welcome'));
     if (sourceBackBtn) sourceBackBtn.addEventListener('click', () => goBack('game'));

--- a/script.js
+++ b/script.js
@@ -405,7 +405,7 @@ function subscribeToComments(questionDate) {
             filter: `question_date=eq.${questionDate}`
         }, async () => {
             await updateCommentCount();
-            if (commentsSection && commentsSection.classList.contains('open')) {
+            if (currentView === 'comments') {
                 await loadComments();
             }
         })
@@ -415,14 +415,11 @@ function subscribeToComments(questionDate) {
 function openComments() {
     if (!commentsSection) return;
     loadComments();
-    commentsSection.classList.add('open');
-    document.body.classList.add('no-scroll');
+    navigateToView('comments');
 }
 
 function closeComments() {
-    if (!commentsSection) return;
-    commentsSection.classList.remove('open');
-    document.body.classList.remove('no-scroll');
+    goBack('game');
 }
 
 // Update the average tries display in the inline meta row
@@ -439,6 +436,7 @@ let completedQuestions = {}; // Changed from array to object to track win/loss s
 // URL Routing state
 let isNavigating = false;
 let currentView = 'welcome';
+let viewHistory = [];
 let todaysQuestion = null;
 
 // Statistics
@@ -1002,9 +1000,8 @@ const hintText = document.getElementById('hint-text');
 const hintBody = document.getElementById('hint-body');
 const questionMeta = document.getElementById('question-meta');
 const sourceBtn = document.getElementById('source-btn');
-const sourceModal = document.getElementById('source-modal');
+const sourceView = document.getElementById('source-view');
 const sourceText = document.getElementById('source-text');
-const closeSourceBtn = document.getElementById('close-source-btn');
 const gameResult = document.getElementById('game-result');
 const resultMessage = document.getElementById('result-message');
 const resultEmoji = document.getElementById('result-emoji');
@@ -1039,15 +1036,13 @@ const modalAnswer = document.getElementById('modal-answer');
 const newGameBtn = document.getElementById('new-game-btn');
 const helpBtn = document.getElementById('help-btn');
 const statsBtn = document.getElementById('stats-btn');
-const helpModal = document.getElementById('help-modal');
-const statsModal = document.getElementById('stats-modal');
+const helpView = document.getElementById('help-view');
+const statsView = document.getElementById('stats-view');
 const questionsModal = document.getElementById('questions-modal');
 const strategyTipsBtn = document.getElementById('strategy-tips-btn');
 // Hint elements
 const hintModalBtn = document.getElementById('hint-modal-btn');
 const questionsList = document.getElementById('questions-list');
-const closeHelpBtn = document.getElementById('close-help-btn');
-const closeStatsBtn = document.getElementById('close-stats-btn');
 const closeQuestionsBtn = document.getElementById('close-questions-btn');
 const shareBtn = document.getElementById('share-btn');
 const shareStatsBtn = document.getElementById('share-stats-btn');
@@ -1065,6 +1060,20 @@ const commentsList = document.getElementById('comments-list');
 const commentInput = document.getElementById('comment-input');
 const commentSubmitBtn = document.getElementById('comment-submit-btn');
 const commentCountEl = document.getElementById('comment-count');
+const helpBackBtn = document.getElementById('help-back-btn');
+const statsBackBtn = document.getElementById('stats-back-btn');
+const sourceBackBtn = document.getElementById('source-back-btn');
+const calendarBackBtn = document.getElementById('calendar-back-btn');
+
+const viewElements = {
+    welcome: welcomeScreen,
+    game: gameView,
+    calendar: calendarView,
+    help: helpView,
+    stats: statsView,
+    source: sourceView,
+    comments: commentsSection
+};
 
 
 // Confidence tooltip
@@ -1369,21 +1378,20 @@ function setActiveView(view, options = {}) {
             renderCalendar();
         } else if (view === 'welcome') {
             refreshDailyChallengeSummary();
+        } else if (view === 'game') {
+            if (guessInput && !('ontouchstart' in window) && !navigator.maxTouchPoints) {
+                setTimeout(() => guessInput.focus(), 150);
+            }
         }
         return;
     }
 
     currentView = view;
 
-    if (welcomeScreen) {
-        welcomeScreen.classList.toggle('active', view === 'welcome');
-    }
-    if (gameView) {
-        gameView.classList.toggle('active', view === 'game');
-    }
-    if (calendarView) {
-        calendarView.classList.toggle('active', view === 'calendar');
-    }
+    Object.entries(viewElements).forEach(([key, element]) => {
+        if (!element) return;
+        element.classList.toggle('active', key === view);
+    });
 
     if (!skipURLUpdate) {
         if (view === 'welcome') {
@@ -1401,6 +1409,31 @@ function setActiveView(view, options = {}) {
         if (guessInput && !('ontouchstart' in window) && !navigator.maxTouchPoints) {
             setTimeout(() => guessInput.focus(), 150);
         }
+    }
+}
+
+function navigateToView(view, options = {}) {
+    const { skipHistory = false, skipURLUpdate, force = false } = options;
+    if (!skipHistory && currentView !== view) {
+        viewHistory.push(currentView);
+    }
+    const shouldSkipURL = skipURLUpdate !== undefined
+        ? skipURLUpdate
+        : !['welcome', 'calendar'].includes(view);
+    setActiveView(view, { skipURLUpdate: shouldSkipURL, force });
+}
+
+function goBack(fallbackView = 'welcome') {
+    if (viewHistory.length > 0) {
+        const previous = viewHistory.pop();
+        const skipURLUpdate = !['welcome', 'calendar'].includes(previous);
+        setActiveView(previous, { skipURLUpdate, force: true });
+        return;
+    }
+
+    if (fallbackView) {
+        const skipURLUpdate = !['welcome', 'calendar'].includes(fallbackView);
+        setActiveView(fallbackView, { skipURLUpdate, force: true });
     }
 }
 
@@ -2074,15 +2107,17 @@ function startNewGameFromModal() {
     startNewGame();
 }
 
-// Show help modal
+// Show help view
 function showHelp() {
-    helpModal.style.display = 'block';
+    if (!helpView) return;
+    navigateToView('help');
 }
 
-// Show stats modal
+// Show stats view
 function showStats() {
     updateStatsDisplay();
-    statsModal.style.display = 'block';
+    if (!statsView) return;
+    navigateToView('stats');
 }
 
 // Update stats display
@@ -3300,19 +3335,19 @@ function setupEventListeners() {
 
     if (calendarLinkBtn) {
         calendarLinkBtn.addEventListener('click', () => {
-            setActiveView('calendar');
+            navigateToView('calendar');
         });
     }
 
     if (homeBtn) {
         homeBtn.addEventListener('click', () => {
-            setActiveView('welcome');
+            navigateToView('welcome');
         });
     }
 
     if (calendarBtn) {
         calendarBtn.addEventListener('click', () => {
-            setActiveView('calendar');
+            navigateToView('calendar');
         });
     }
 
@@ -3419,8 +3454,8 @@ function setupEventListeners() {
         updateSelected(confidenceInput.value);
     }
     
-    // Source button opens explanation modal
-    if (sourceBtn && sourceModal) {
+    // Source button opens explanation view
+    if (sourceBtn && sourceView) {
         sourceBtn.addEventListener('click', () => {
             if (currentQuestion && sourceText) {
                 const explanation = currentQuestion.explanation || 'No source available for this question as of now. This is a new feature that will be available in the coming days.';
@@ -3477,7 +3512,7 @@ function setupEventListeners() {
                     })
                     .catch(() => {/* ignore */});
             }
-            sourceModal.style.display = 'block';
+            navigateToView('source');
         });
     }
 
@@ -3497,9 +3532,9 @@ function setupEventListeners() {
     });
     
     // Close buttons
-    closeHelpBtn.addEventListener('click', () => closeModal(helpModal));
-    closeStatsBtn.addEventListener('click', () => closeModal(statsModal));
-    closeQuestionsBtn.addEventListener('click', () => closeModal(questionsModal));
+    if (closeQuestionsBtn) {
+        closeQuestionsBtn.addEventListener('click', () => closeModal(questionsModal));
+    }
 
     // Comment buttons
     if (commentsBtn) commentsBtn.addEventListener('click', openComments);
@@ -3517,9 +3552,10 @@ function setupEventListeners() {
     // Share buttons
     shareBtn.addEventListener('click', shareGame);
     shareStatsBtn.addEventListener('click', shareStats);
-        
+
     // Close modals when clicking outside (desktop + mobile)
-    [helpModal, statsModal, questionsModal, sourceModal].forEach(modal => {
+    [questionsModal, gameOverModal].forEach(modal => {
+        if (!modal) return;
         ['click', 'touchend'].forEach(event => {
             modal.addEventListener(event, e => e.target === modal && closeModal(modal));
         });
@@ -3532,10 +3568,11 @@ function setupEventListeners() {
         });
     });
 
-    // Close source modal via button
-    if (closeSourceBtn && sourceModal) {
-        closeSourceBtn.addEventListener('click', () => closeModal(sourceModal));
-    }
+    // Back buttons for secondary views
+    if (helpBackBtn) helpBackBtn.addEventListener('click', () => goBack('welcome'));
+    if (statsBackBtn) statsBackBtn.addEventListener('click', () => goBack('welcome'));
+    if (sourceBackBtn) sourceBackBtn.addEventListener('click', () => goBack('game'));
+    if (calendarBackBtn) calendarBackBtn.addEventListener('click', () => goBack('welcome'));
 }
 
 if (calibrationChart) {

--- a/script.js
+++ b/script.js
@@ -991,6 +991,7 @@ const gameView = document.getElementById('game-view');
 const calendarView = document.getElementById('calendar-view');
 const playDailyBtn = document.getElementById('play-daily-btn');
 const calendarLinkBtn = document.getElementById('calendar-link-btn');
+const learnMoreBtn = document.getElementById('learn-more-btn');
 const homeBtn = document.getElementById('home-btn');
 const calendarBtn = document.getElementById('calendar-btn');
 const dailyChallengeCard = document.getElementById('daily-challenge-card');
@@ -3362,6 +3363,10 @@ function setupEventListeners() {
         calendarLinkBtn.addEventListener('click', () => {
             navigateToView('calendar');
         });
+    }
+
+    if (learnMoreBtn) {
+        learnMoreBtn.addEventListener('click', showHelp);
     }
 
     if (homeBtn) {

--- a/script.js
+++ b/script.js
@@ -3147,7 +3147,7 @@ function showShareFeedback(message) {
         color: white;
         padding: 12px 20px;
         border-radius: 8px;
-        font-family: 'Press Start 2P', monospace;
+        font-family: 'Nunito', sans-serif;
         font-size: 0.7rem;
         z-index: 10000;
     `;

--- a/script.js
+++ b/script.js
@@ -413,9 +413,9 @@ function subscribeToComments(questionDate) {
 }
 
 function openComments() {
-    if (!commentsSection) return;
+    if (!commentsSection || !currentQuestion) return;
     loadComments();
-    navigateToView('comments');
+    navigateToView('comments', { date: currentQuestion.date });
 }
 
 function closeComments() {
@@ -1154,14 +1154,36 @@ function initGame() {
                 updateStatsDisplay();
                 setActiveView('stats', { skipURLUpdate: true, force: true });
                 break;
-            case 'source':
+            case 'source': {
+                const targetDate = initialRoute.date || (currentQuestion ? currentQuestion.date : null);
+                if (initialRoute.date) {
+                    if (!ensureQuestionSelected(initialRoute.date)) {
+                        navigateToCurrentQuestion();
+                        break;
+                    }
+                } else if (!ensureQuestionSelected(targetDate)) {
+                    navigateToCurrentQuestion();
+                    break;
+                }
                 prepareSourceView();
-                setActiveView('source', { skipURLUpdate: true, force: true });
+                setActiveView('source', { skipURLUpdate: true, force: true, date: targetDate || (currentQuestion ? currentQuestion.date : null) });
                 break;
-            case 'comments':
+            }
+            case 'comments': {
+                const targetDate = initialRoute.date || (currentQuestion ? currentQuestion.date : null);
+                if (initialRoute.date) {
+                    if (!ensureQuestionSelected(initialRoute.date)) {
+                        navigateToCurrentQuestion();
+                        break;
+                    }
+                } else if (!ensureQuestionSelected(targetDate)) {
+                    navigateToCurrentQuestion();
+                    break;
+                }
                 void loadComments();
-                setActiveView('comments', { skipURLUpdate: true, force: true });
+                setActiveView('comments', { skipURLUpdate: true, force: true, date: targetDate || (currentQuestion ? currentQuestion.date : null) });
                 break;
+            }
             case 'welcome':
             default:
                 setActiveView('welcome', { force: true });
@@ -1423,8 +1445,27 @@ function updateHash(newHash) {
     }
 }
 
+function getHashForView(view, date) {
+    switch (view) {
+        case 'welcome':
+            return '#/welcome';
+        case 'calendar':
+            return '#/calendar';
+        case 'help':
+            return '#/help';
+        case 'stats':
+            return '#/stats';
+        case 'source':
+            return date ? `#/${date}/source` : '#/source';
+        case 'comments':
+            return date ? `#/${date}/comments` : '#/comments';
+        default:
+            return null;
+    }
+}
+
 function setActiveView(view, options = {}) {
-    const { skipURLUpdate = false, force = false } = options;
+    const { skipURLUpdate = false, force = false, date } = options;
     if (!force && currentView === view) {
         if (view === 'calendar') {
             renderCalendar();
@@ -1446,18 +1487,10 @@ function setActiveView(view, options = {}) {
     });
 
     if (!skipURLUpdate) {
-        if (view === 'welcome') {
-            updateHash('#/welcome');
-        } else if (view === 'calendar') {
-            updateHash('#/calendar');
-        } else if (view === 'help') {
-            updateHash('#/help');
-        } else if (view === 'stats') {
-            updateHash('#/stats');
-        } else if (view === 'source') {
-            updateHash('#/source');
-        } else if (view === 'comments') {
-            updateHash('#/comments');
+        const viewDate = date || (currentQuestion ? currentQuestion.date : null);
+        const newHash = getHashForView(view, viewDate);
+        if (newHash) {
+            updateHash(newHash);
         }
     }
 
@@ -1473,27 +1506,41 @@ function setActiveView(view, options = {}) {
 }
 
 function navigateToView(view, options = {}) {
-    const { skipHistory = false, skipURLUpdate, force = false } = options;
+    const { skipHistory = false, skipURLUpdate, force = false, date } = options;
     if (!skipHistory && currentView !== view) {
         viewHistory.push(currentView);
     }
     const shouldSkipURL = skipURLUpdate !== undefined
         ? skipURLUpdate
         : !urlSyncedViews.has(view);
-    setActiveView(view, { skipURLUpdate: shouldSkipURL, force });
+    setActiveView(view, { skipURLUpdate: shouldSkipURL, force, date });
 }
 
 function goBack(fallbackView = 'welcome') {
     if (viewHistory.length > 0) {
         const previous = viewHistory.pop();
         const skipURLUpdate = !urlSyncedViews.has(previous);
-        setActiveView(previous, { skipURLUpdate, force: true });
+        const options = { skipURLUpdate, force: true };
+        if ((previous === 'source' || previous === 'comments') && currentQuestion) {
+            options.date = currentQuestion.date;
+        }
+        setActiveView(previous, options);
+        if (previous === 'game' && currentQuestion) {
+            updateURL(currentQuestion.date);
+        }
         return;
     }
 
     if (fallbackView) {
         const skipURLUpdate = !urlSyncedViews.has(fallbackView);
-        setActiveView(fallbackView, { skipURLUpdate, force: true });
+        const options = { skipURLUpdate, force: true };
+        if ((fallbackView === 'source' || fallbackView === 'comments') && currentQuestion) {
+            options.date = currentQuestion.date;
+        }
+        setActiveView(fallbackView, options);
+        if (fallbackView === 'game' && currentQuestion) {
+            updateURL(currentQuestion.date);
+        }
     }
 }
 
@@ -3314,6 +3361,11 @@ function parseURL() {
         return { view: 'stats' };
     }
 
+    const datedViewMatch = hash.match(/^#\/(\d{4}-\d{2}-\d{2})\/(comments|source)$/);
+    if (datedViewMatch) {
+        return { view: datedViewMatch[2], date: datedViewMatch[1] };
+    }
+
     if (hash === '#/source') {
         return { view: 'source' };
     }
@@ -3332,6 +3384,40 @@ function parseURL() {
     }
 
     return { view: 'welcome' };
+}
+
+function ensureQuestionSelected(questionDate) {
+    if (questionDate) {
+        if (currentQuestion && currentQuestion.date === questionDate) {
+            return true;
+        }
+        const question = getQuestionForDate(questionDate);
+        if (!question) {
+            return false;
+        }
+        const today = getCurrentDate();
+        if (question.date > today) {
+            return false;
+        }
+        isNavigating = true;
+        selectQuestion(question);
+        isNavigating = false;
+        return true;
+    }
+
+    if (currentQuestion) {
+        return true;
+    }
+
+    const defaultQuestion = getCurrentQuestion();
+    if (!defaultQuestion) {
+        return false;
+    }
+
+    isNavigating = true;
+    selectQuestion(defaultQuestion);
+    isNavigating = false;
+    return true;
 }
 
 // Navigate to a specific question by date
@@ -3389,14 +3475,32 @@ function handlePopState() {
             updateStatsDisplay();
             setActiveView('stats', { skipURLUpdate: true, force: true });
             return;
-        case 'source':
+        case 'source': {
+            const targetDate = route.date || (currentQuestion ? currentQuestion.date : null);
+            if (route.date && !ensureQuestionSelected(route.date)) {
+                navigateToCurrentQuestion();
+                return;
+            } else if (!route.date && !ensureQuestionSelected(targetDate)) {
+                navigateToCurrentQuestion();
+                return;
+            }
             prepareSourceView();
-            setActiveView('source', { skipURLUpdate: true, force: true });
+            setActiveView('source', { skipURLUpdate: true, force: true, date: targetDate || (currentQuestion ? currentQuestion.date : null) });
             return;
-        case 'comments':
+        }
+        case 'comments': {
+            const targetDate = route.date || (currentQuestion ? currentQuestion.date : null);
+            if (route.date && !ensureQuestionSelected(route.date)) {
+                navigateToCurrentQuestion();
+                return;
+            } else if (!route.date && !ensureQuestionSelected(targetDate)) {
+                navigateToCurrentQuestion();
+                return;
+            }
             void loadComments();
-            setActiveView('comments', { skipURLUpdate: true, force: true });
+            setActiveView('comments', { skipURLUpdate: true, force: true, date: targetDate || (currentQuestion ? currentQuestion.date : null) });
             return;
+        }
         case 'game':
             if (route.date) {
                 if (!navigateToQuestion(route.date)) {
@@ -3443,14 +3547,36 @@ function initRouting(skipInitialNavigation = false) {
             updateStatsDisplay();
             setActiveView('stats', { skipURLUpdate: true, force: true });
             break;
-        case 'source':
+        case 'source': {
+            const targetDate = route.date || (currentQuestion ? currentQuestion.date : null);
+            if (route.date) {
+                if (!ensureQuestionSelected(route.date)) {
+                    navigateToCurrentQuestion();
+                    break;
+                }
+            } else if (!ensureQuestionSelected(targetDate)) {
+                navigateToCurrentQuestion();
+                break;
+            }
             prepareSourceView();
-            setActiveView('source', { skipURLUpdate: true, force: true });
+            setActiveView('source', { skipURLUpdate: true, force: true, date: targetDate || (currentQuestion ? currentQuestion.date : null) });
             break;
-        case 'comments':
+        }
+        case 'comments': {
+            const targetDate = route.date || (currentQuestion ? currentQuestion.date : null);
+            if (route.date) {
+                if (!ensureQuestionSelected(route.date)) {
+                    navigateToCurrentQuestion();
+                    break;
+                }
+            } else if (!ensureQuestionSelected(targetDate)) {
+                navigateToCurrentQuestion();
+                break;
+            }
             void loadComments();
-            setActiveView('comments', { skipURLUpdate: true, force: true });
+            setActiveView('comments', { skipURLUpdate: true, force: true, date: targetDate || (currentQuestion ? currentQuestion.date : null) });
             break;
+        }
         case 'welcome':
         default:
             setActiveView('welcome', { force: true });
@@ -3633,8 +3759,9 @@ function setupEventListeners() {
     // Source button opens explanation view
     if (sourceBtn && sourceView) {
         sourceBtn.addEventListener('click', () => {
+            if (!currentQuestion) return;
             prepareSourceView();
-            navigateToView('source');
+            navigateToView('source', { date: currentQuestion.date });
         });
     }
 

--- a/script.js
+++ b/script.js
@@ -994,6 +994,9 @@ const welcomeScreen = document.getElementById('welcome-screen');
 const gameView = document.getElementById('game-view');
 const calendarView = document.getElementById('calendar-view');
 const gameBackBtn = document.getElementById('game-back-btn');
+if (gameBackBtn) {
+    setGameBackDestination(gameBackFallback);
+}
 const playDailyBtn = document.getElementById('play-daily-btn');
 const calendarLinkBtn = document.getElementById('calendar-link-btn');
 const learnMoreBtn = document.getElementById('learn-more-btn');
@@ -1309,19 +1312,23 @@ function getCurrentDate() {
     return `${year}-${month}-${day}`;
 }
 
-function updateGameBackFallback(question, sourceView = currentView) {
+function setGameBackDestination(destination) {
+    const target = destination === 'calendar' ? 'calendar' : 'welcome';
+    gameBackFallback = target;
+    if (gameBackBtn) {
+        gameBackBtn.textContent = target === 'calendar' ? 'Back to calendar' : 'Back';
+    }
+}
+
+function updateGameBackFallback(_question, sourceView = currentView) {
     if (sourceView === 'calendar') {
-        gameBackFallback = 'calendar';
+        setGameBackDestination('calendar');
         return;
     }
 
-    if (question && question.date) {
-        const today = getCurrentDate();
-        gameBackFallback = question.date === today ? 'welcome' : 'calendar';
-        return;
+    if (sourceView !== 'game') {
+        setGameBackDestination('welcome');
     }
-
-    gameBackFallback = 'welcome';
 }
 
 // Get question for a specific date

--- a/script.js
+++ b/script.js
@@ -984,11 +984,10 @@ const playDailyBtn = document.getElementById('play-daily-btn');
 const calendarLinkBtn = document.getElementById('calendar-link-btn');
 const homeBtn = document.getElementById('home-btn');
 const calendarBtn = document.getElementById('calendar-btn');
+const dailyChallengeCard = document.getElementById('daily-challenge-card');
 const dailyChallengeQuestionEl = document.getElementById('daily-challenge-question');
 const dailyChallengeDateEl = document.getElementById('daily-challenge-date');
 const dailyChallengeStatusEl = document.getElementById('daily-challenge-status');
-const dailyChallengeImageContainer = document.getElementById('daily-challenge-image-container');
-const dailyChallengeImageEl = document.getElementById('daily-challenge-image');
 const calendarMonthsContainer = document.getElementById('calendar-months');
 const questionText = document.getElementById('question-text');
 const questionCategory = document.getElementById('question-category');
@@ -1259,6 +1258,14 @@ function formatDateForDisplay(dateString) {
     return date.toLocaleDateString('en-GB', options);
 }
 
+function formatDateForBadge(dateString) {
+    const date = new Date(dateString);
+    if (Number.isNaN(date.getTime())) {
+        return '';
+    }
+    return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+}
+
 // Get question based on current date and game state
 function getCurrentQuestion() {
     const today = getCurrentDate();
@@ -1301,15 +1308,22 @@ function refreshDailyChallengeSummary() {
     const todayQuestion = getTodaysQuestion();
     todaysQuestion = todayQuestion || null;
 
+    if (dailyChallengeCard) {
+        dailyChallengeCard.classList.remove(
+            'daily-challenge-card--ready',
+            'daily-challenge-card--won',
+            'daily-challenge-card--lost'
+        );
+    }
+
     if (!todayQuestion) {
         dailyChallengeQuestionEl.textContent = 'No daily challenge is available right now.';
         dailyChallengeDateEl.textContent = '';
+        dailyChallengeDateEl.removeAttribute('title');
+        dailyChallengeDateEl.removeAttribute('aria-label');
         if (dailyChallengeStatusEl) {
             dailyChallengeStatusEl.textContent = '';
             dailyChallengeStatusEl.classList.remove('status-won', 'status-lost');
-        }
-        if (dailyChallengeImageContainer) {
-            dailyChallengeImageContainer.style.display = 'none';
         }
         if (playDailyBtn) {
             playDailyBtn.disabled = true;
@@ -1318,25 +1332,19 @@ function refreshDailyChallengeSummary() {
         return;
     }
 
-    const todayDate = getCurrentDate();
-    const formattedDate = todayQuestion.date === todayDate
-        ? 'Today'
-        : formatDateForDisplay(todayQuestion.date);
+    const badgeDate = formatDateForBadge(todayQuestion.date);
+    const fullDateLabel = formatDateForDisplay(todayQuestion.date);
 
-    dailyChallengeDateEl.textContent = formattedDate;
-    dailyChallengeQuestionEl.textContent = todayQuestion.question;
-
-    if (dailyChallengeImageContainer) {
-        if (todayQuestion.image) {
-            dailyChallengeImageContainer.style.display = 'flex';
-            if (dailyChallengeImageEl) {
-                dailyChallengeImageEl.src = todayQuestion.image;
-                dailyChallengeImageEl.alt = `Image for ${todayQuestion.question}`;
-            }
-        } else {
-            dailyChallengeImageContainer.style.display = 'none';
-        }
+    dailyChallengeDateEl.textContent = badgeDate;
+    if (fullDateLabel) {
+        dailyChallengeDateEl.title = fullDateLabel;
+        dailyChallengeDateEl.setAttribute('aria-label', `Question date: ${fullDateLabel}`);
+    } else {
+        dailyChallengeDateEl.removeAttribute('title');
+        dailyChallengeDateEl.removeAttribute('aria-label');
     }
+
+    dailyChallengeQuestionEl.textContent = todayQuestion.question;
 
     if (playDailyBtn) {
         playDailyBtn.disabled = false;
@@ -1355,12 +1363,20 @@ function refreshDailyChallengeSummary() {
         if (playDailyBtn) {
             playDailyBtn.textContent = 'Review';
         }
+        if (dailyChallengeCard) {
+            dailyChallengeCard.classList.add(
+                completed.won ? 'daily-challenge-card--won' : 'daily-challenge-card--lost'
+            );
+        }
     } else {
         if (dailyChallengeStatusEl) {
             dailyChallengeStatusEl.textContent = 'Ready to play';
         }
         if (playDailyBtn) {
             playDailyBtn.textContent = 'Play';
+        }
+        if (dailyChallengeCard) {
+            dailyChallengeCard.classList.add('daily-challenge-card--ready');
         }
     }
 }

--- a/script.js
+++ b/script.js
@@ -414,7 +414,10 @@ function subscribeToComments(questionDate) {
 
 function openComments() {
     if (!commentsSection || !currentQuestion) return;
-    loadComments();
+    if (!ensureExtrasAccessible(currentQuestion.date)) {
+        return;
+    }
+    void loadComments();
     navigateToView('comments', { date: currentQuestion.date });
 }
 
@@ -1156,32 +1159,30 @@ function initGame() {
                 break;
             case 'source': {
                 const targetDate = initialRoute.date || (currentQuestion ? currentQuestion.date : null);
-                if (initialRoute.date) {
-                    if (!ensureQuestionSelected(initialRoute.date)) {
-                        navigateToCurrentQuestion();
-                        break;
-                    }
-                } else if (!ensureQuestionSelected(targetDate)) {
+                if (!ensureExtrasAccessible(targetDate)) {
+                    break;
+                }
+                const resolvedDate = targetDate || (currentQuestion ? currentQuestion.date : null);
+                if (!ensureQuestionSelected(resolvedDate)) {
                     navigateToCurrentQuestion();
                     break;
                 }
                 prepareSourceView();
-                setActiveView('source', { skipURLUpdate: true, force: true, date: targetDate || (currentQuestion ? currentQuestion.date : null) });
+                setActiveView('source', { skipURLUpdate: true, force: true, date: resolvedDate });
                 break;
             }
             case 'comments': {
                 const targetDate = initialRoute.date || (currentQuestion ? currentQuestion.date : null);
-                if (initialRoute.date) {
-                    if (!ensureQuestionSelected(initialRoute.date)) {
-                        navigateToCurrentQuestion();
-                        break;
-                    }
-                } else if (!ensureQuestionSelected(targetDate)) {
+                if (!ensureExtrasAccessible(targetDate)) {
+                    break;
+                }
+                const resolvedDate = targetDate || (currentQuestion ? currentQuestion.date : null);
+                if (!ensureQuestionSelected(resolvedDate)) {
                     navigateToCurrentQuestion();
                     break;
                 }
                 void loadComments();
-                setActiveView('comments', { skipURLUpdate: true, force: true, date: targetDate || (currentQuestion ? currentQuestion.date : null) });
+                setActiveView('comments', { skipURLUpdate: true, force: true, date: resolvedDate });
                 break;
             }
             case 'welcome':
@@ -1507,6 +1508,14 @@ function setActiveView(view, options = {}) {
 
 function navigateToView(view, options = {}) {
     const { skipHistory = false, skipURLUpdate, force = false, date } = options;
+
+    if (view === 'source' || view === 'comments') {
+        const targetDate = date || (currentQuestion ? currentQuestion.date : null);
+        if (!ensureExtrasAccessible(targetDate)) {
+            return;
+        }
+    }
+
     if (!skipHistory && currentView !== view) {
         viewHistory.push(currentView);
     }
@@ -3420,6 +3429,25 @@ function ensureQuestionSelected(questionDate) {
     return true;
 }
 
+function hasCompletedQuestion(questionDate) {
+    if (!questionDate) return false;
+    return Boolean(completedQuestions && completedQuestions[questionDate]);
+}
+
+function ensureExtrasAccessible(questionDate) {
+    if (!questionDate) {
+        navigateToCurrentQuestion();
+        return false;
+    }
+
+    if (!hasCompletedQuestion(questionDate)) {
+        navigateToQuestion(questionDate);
+        return false;
+    }
+
+    return true;
+}
+
 // Navigate to a specific question by date
 function navigateToQuestion(questionDate) {
     const question = getQuestionForDate(questionDate);
@@ -3477,28 +3505,30 @@ function handlePopState() {
             return;
         case 'source': {
             const targetDate = route.date || (currentQuestion ? currentQuestion.date : null);
-            if (route.date && !ensureQuestionSelected(route.date)) {
-                navigateToCurrentQuestion();
+            if (!ensureExtrasAccessible(targetDate)) {
                 return;
-            } else if (!route.date && !ensureQuestionSelected(targetDate)) {
+            }
+            const resolvedDate = targetDate || (currentQuestion ? currentQuestion.date : null);
+            if (!ensureQuestionSelected(resolvedDate)) {
                 navigateToCurrentQuestion();
                 return;
             }
             prepareSourceView();
-            setActiveView('source', { skipURLUpdate: true, force: true, date: targetDate || (currentQuestion ? currentQuestion.date : null) });
+            setActiveView('source', { skipURLUpdate: true, force: true, date: resolvedDate });
             return;
         }
         case 'comments': {
             const targetDate = route.date || (currentQuestion ? currentQuestion.date : null);
-            if (route.date && !ensureQuestionSelected(route.date)) {
-                navigateToCurrentQuestion();
+            if (!ensureExtrasAccessible(targetDate)) {
                 return;
-            } else if (!route.date && !ensureQuestionSelected(targetDate)) {
+            }
+            const resolvedDate = targetDate || (currentQuestion ? currentQuestion.date : null);
+            if (!ensureQuestionSelected(resolvedDate)) {
                 navigateToCurrentQuestion();
                 return;
             }
             void loadComments();
-            setActiveView('comments', { skipURLUpdate: true, force: true, date: targetDate || (currentQuestion ? currentQuestion.date : null) });
+            setActiveView('comments', { skipURLUpdate: true, force: true, date: resolvedDate });
             return;
         }
         case 'game':
@@ -3549,32 +3579,30 @@ function initRouting(skipInitialNavigation = false) {
             break;
         case 'source': {
             const targetDate = route.date || (currentQuestion ? currentQuestion.date : null);
-            if (route.date) {
-                if (!ensureQuestionSelected(route.date)) {
-                    navigateToCurrentQuestion();
-                    break;
-                }
-            } else if (!ensureQuestionSelected(targetDate)) {
+            if (!ensureExtrasAccessible(targetDate)) {
+                break;
+            }
+            const resolvedDate = targetDate || (currentQuestion ? currentQuestion.date : null);
+            if (!ensureQuestionSelected(resolvedDate)) {
                 navigateToCurrentQuestion();
                 break;
             }
             prepareSourceView();
-            setActiveView('source', { skipURLUpdate: true, force: true, date: targetDate || (currentQuestion ? currentQuestion.date : null) });
+            setActiveView('source', { skipURLUpdate: true, force: true, date: resolvedDate });
             break;
         }
         case 'comments': {
             const targetDate = route.date || (currentQuestion ? currentQuestion.date : null);
-            if (route.date) {
-                if (!ensureQuestionSelected(route.date)) {
-                    navigateToCurrentQuestion();
-                    break;
-                }
-            } else if (!ensureQuestionSelected(targetDate)) {
+            if (!ensureExtrasAccessible(targetDate)) {
+                break;
+            }
+            const resolvedDate = targetDate || (currentQuestion ? currentQuestion.date : null);
+            if (!ensureQuestionSelected(resolvedDate)) {
                 navigateToCurrentQuestion();
                 break;
             }
             void loadComments();
-            setActiveView('comments', { skipURLUpdate: true, force: true, date: targetDate || (currentQuestion ? currentQuestion.date : null) });
+            setActiveView('comments', { skipURLUpdate: true, force: true, date: resolvedDate });
             break;
         }
         case 'welcome':
@@ -3760,8 +3788,13 @@ function setupEventListeners() {
     if (sourceBtn && sourceView) {
         sourceBtn.addEventListener('click', () => {
             if (!currentQuestion) return;
+            const targetDate = currentQuestion.date;
+            if (!hasCompletedQuestion(targetDate)) {
+                navigateToQuestion(targetDate);
+                return;
+            }
             prepareSourceView();
-            navigateToView('source', { date: currentQuestion.date });
+            navigateToView('source', { date: targetDate });
         });
     }
 

--- a/styles.css
+++ b/styles.css
@@ -1230,7 +1230,7 @@ button#stats-btn {
     --card-accent: #e9ecef;
     border: 4px solid var(--card-accent);
     border-radius: 18px;
-    padding: 24px;
+    padding: 20px;
     display: flex;
     flex-direction: column;
     gap: 18px;
@@ -1592,7 +1592,7 @@ button.calendar-cell:disabled {
     }
 
     .daily-challenge-card {
-        padding: 18px;
+        padding: 20px;
     }
 }
 

--- a/styles.css
+++ b/styles.css
@@ -1228,6 +1228,9 @@ button#stats-btn {
 
 .daily-challenge-card {
     --card-accent: #e9ecef;
+    --primary-action-bg: var(--card-accent);
+    --primary-action-shadow: var(--card-accent);
+    --primary-action-text: #0f172a;
     border: 4px solid var(--card-accent);
     border-radius: 18px;
     padding: 20px;
@@ -1241,20 +1244,23 @@ button#stats-btn {
 
 .daily-challenge-card--ready {
     --card-accent: #1cb0f6;
+    --primary-action-bg: #1cb0f6;
+    --primary-action-shadow: #1999d6;
+    --primary-action-text: #fff;
 }
 
 .daily-challenge-card--won {
     --card-accent: #15803d;
+    --primary-action-bg: var(--card-accent);
+    --primary-action-shadow: var(--card-accent);
+    --primary-action-text: #fff;
 }
 
 .daily-challenge-card--lost {
     --card-accent: #b91c1c;
-}
-
-.daily-challenge-card--ready .daily-challenge-date-badge,
-.daily-challenge-card--won .daily-challenge-date-badge,
-.daily-challenge-card--lost .daily-challenge-date-badge {
-    color: #fff;
+    --primary-action-bg: var(--card-accent);
+    --primary-action-shadow: var(--card-accent);
+    --primary-action-text: #fff;
 }
 
 .daily-challenge-date-badge {
@@ -1263,12 +1269,11 @@ button#stats-btn {
     right: -4px;
     background: var(--card-accent);
     color: #0f172a;
-    font-size: 0.75rem;
+    font-size: 15px;
     font-weight: 700;
-    letter-spacing: 0.08em;
     text-transform: uppercase;
-    padding: 6px 12px;
-    border-radius: 0 14px 0 12px;
+    padding: 5px 14px;
+    border-radius: 0 18px 0 18px;
 }
 
 .daily-challenge-date-badge:empty {
@@ -1295,9 +1300,10 @@ button#stats-btn {
 }
 
 .daily-challenge-question {
-    font-size: 0.82rem;
-    line-height: 1.6;
+    font-size: 21px;
+    line-height: 28px;
     color: #0f172a;
+    font-weight: 700;
 }
 
 .daily-challenge-status {
@@ -1335,21 +1341,28 @@ button#stats-btn {
 }
 
 .primary-action {
-    background: #0f172a;
-    color: #fff;
-    padding: 16px 18px;
+    background: var(--primary-action-bg, #1cb0f6);
+    color: var(--primary-action-text, #fff);
+    padding: 11.25px 18px;
     border: none;
-    box-shadow: 0 10px 18px rgba(15, 23, 42, 0.18);
+    box-shadow: 0 4px 0 var(--primary-action-shadow, #1999d6);
 }
 
 .primary-action:hover {
     transform: translateY(-1px);
-    box-shadow: 0 14px 24px rgba(15, 23, 42, 0.2);
+    box-shadow: 0 6px 0 var(--primary-action-shadow, #1999d6);
 }
 
 .primary-action:active {
     transform: translateY(0);
-    box-shadow: 0 6px 12px rgba(15, 23, 42, 0.15);
+    box-shadow: 0 2px 0 var(--primary-action-shadow, #1999d6);
+}
+
+.primary-action:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+    box-shadow: none;
+    transform: none;
 }
 
 .secondary-action {
@@ -1552,10 +1565,6 @@ button.calendar-cell:disabled {
     .daily-challenge-body {
         align-items: flex-start;
         gap: 10px;
-    }
-
-    .daily-challenge-question {
-        font-size: 0.78rem;
     }
 
     .calendar-wrapper {

--- a/styles.css
+++ b/styles.css
@@ -1226,6 +1226,43 @@ button#stats-btn {
     gap: 26px;
 }
 
+.welcome-info-card {
+    background: #fff;
+    border: 2px solid #e9ecef;
+    border-radius: 18px;
+    padding: 24px;
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+    text-align: left;
+}
+
+.welcome-info-body {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.welcome-info-body p {
+    margin: 0;
+}
+
+.welcome-info-note {
+    font-size: 0.95rem;
+    color: #64748b;
+    line-height: 1.55;
+}
+
+.welcome-info-actions {
+    display: flex;
+    justify-content: flex-start;
+    align-items: flex-start;
+}
+
+.welcome-info-actions .secondary-action {
+    align-self: flex-start;
+}
+
 .daily-challenge-card {
     --card-accent: #e9ecef;
     --primary-action-bg: var(--card-accent);
@@ -1250,9 +1287,9 @@ button#stats-btn {
 }
 
 .daily-challenge-card--won {
-    --card-accent: #15803d;
+    --card-accent: #58cc02;
     --primary-action-bg: var(--card-accent);
-    --primary-action-shadow: var(--card-accent);
+    --primary-action-shadow: #57a700;
     --primary-action-text: #fff;
 }
 
@@ -1268,7 +1305,7 @@ button#stats-btn {
     top: -4px;
     right: -4px;
     background: var(--card-accent);
-    color: #0f172a;
+    color: #fff;
     font-size: 15px;
     font-weight: 700;
     text-transform: uppercase;
@@ -1601,6 +1638,10 @@ button.calendar-cell:disabled {
     }
 
     .daily-challenge-card {
+        padding: 20px;
+    }
+
+    .welcome-info-card {
         padding: 20px;
     }
 }

--- a/styles.css
+++ b/styles.css
@@ -1343,11 +1343,12 @@ button#stats-btn {
 }
 
 .daily-challenge-status {
-    font-size: 0.65rem;
-    color: #475569;
+    font-size: 0.75rem;
+    color: #afafaf;
     margin-top: 6px;
     text-transform: uppercase;
     letter-spacing: 1px;
+    font-weight: 750;
 }
 
 .daily-challenge-actions {
@@ -1423,48 +1424,6 @@ button#stats-btn {
 .calendar-title {
     font-size: 0.95rem;
     margin: 0;
-}
-
-.calendar-subtitle {
-    font-size: 0.72rem;
-    text-align: center;
-    color: #4b5563;
-    margin-bottom: 24px;
-}
-
-.calendar-legend {
-    display: flex;
-    justify-content: center;
-    gap: 18px;
-    flex-wrap: wrap;
-    font-size: 0.58rem;
-    color: #475569;
-    margin-bottom: 24px;
-}
-
-.legend-box {
-    display: inline-block;
-    width: 12px;
-    height: 12px;
-    border-radius: 4px;
-    margin-right: 6px;
-    border: 2px solid #e9ecef;
-    background: #f8fafc;
-}
-
-.legend-box.won {
-    background: #dcfce7;
-    border-color: #16a34a;
-}
-
-.legend-box.lost {
-    background: #fee2e2;
-    border-color: #dc2626;
-}
-
-.legend-box.pending {
-    background: #e2e8f0;
-    border-color: #cbd5f5;
 }
 
 .calendar-months {

--- a/styles.css
+++ b/styles.css
@@ -1498,12 +1498,14 @@ button#stats-btn {
 button.calendar-cell {
     border: 2px solid #e9ecef;
     border-radius: 12px;
+    border-bottom-width: 4px;
     min-height: 48px;
     display: flex;
     align-items: center;
     justify-content: center;
     font-family: 'Nunito', sans-serif;
-    font-size: 0.68rem;
+    font-size: 15px;
+    font-weight: 700;
     background: #fff;
     color: #0f172a;
     cursor: default;
@@ -1559,10 +1561,6 @@ button.calendar-cell:disabled {
     border-color: #0f172a;
 }
 
-.calendar-cell.active {
-    box-shadow: 0 0 0 2px rgba(15, 23, 42, 0.35) inset;
-}
-
 .calendar-month-footer {
     margin-top: 16px;
     font-size: 0.6rem;
@@ -1590,7 +1588,7 @@ button.calendar-cell:disabled {
     .calendar-cell,
     button.calendar-cell {
         min-height: 42px;
-        font-size: 0.6rem;
+        font-size: 0.8rem;
     }
 
     .nav-button {
@@ -1604,11 +1602,6 @@ button.calendar-cell:disabled {
         flex-direction: column;
         align-items: center;
         gap: 10px;
-    }
-
-    .calendar-cell,
-    button.calendar-cell {
-        min-height: 38px;
     }
 
     .daily-challenge-card {

--- a/styles.css
+++ b/styles.css
@@ -5,8 +5,10 @@
 }
 
 body {
-    font-family: 'Press Start 2P', monospace;
-    background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32' width='32' height='32' fill='none' stroke='rgb(15 23 42 / 0.04)'%3e%3cpath d='M0 .5H31.5V32'/%3e%3c/svg%3e");
+    font-family: 'Nunito', sans-serif;
+    background-image:
+        linear-gradient(to bottom, transparent 0%, transparent 15%, rgba(255, 255, 255, 0.8) 50%, white 75%),
+        url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32' width='32' height='32' fill='none' stroke='rgb(15 23 42 / 0.04)'%3e%3cpath d='M0 .5H31.5V32'/%3e%3c/svg%3e");
     color: #333;
     line-height: 1.4;
     padding: 0 16px;
@@ -62,7 +64,7 @@ main {
     border: 2px solid #e9ecef;
     border-radius: 12px;
     padding: 10px 14px;
-    font-family: 'Press Start 2P', monospace;
+    font-family: 'Nunito', sans-serif;
     font-size: 0.6rem;
     color: #0f172a;
     cursor: pointer;
@@ -123,7 +125,7 @@ main {
 
 .nav-button {
     background: #fff;
-    font-family: 'Press Start 2P', monospace;
+    font-family: 'Nunito', sans-serif;
     font-size: 0.6rem;
     color: #0f172a;
     border: 2px solid #e9ecef;
@@ -154,7 +156,7 @@ main {
 .icon-button {
     background: #fff;
     font-size: 1.1rem;
-    font-family: 'Press Start 2P', monospace;
+    font-family: 'Nunito', sans-serif;
     color: #333;
     cursor: pointer;
     padding: 12px;
@@ -263,7 +265,7 @@ button#stats-btn {
     align-items: center;
     justify-content: center;
     gap: 12px;
-    font-family: 'Press Start 2P', monospace;
+    font-family: 'Nunito', sans-serif;
     font-size: 0.8rem;
     cursor: pointer;
 }
@@ -283,7 +285,7 @@ button#stats-btn {
 .source-btn {
     background: white;
     border: 2px solid #e9ecef;
-    font-family: 'Press Start 2P', monospace;
+    font-family: 'Nunito', sans-serif;
     font-size: 0.8rem;
     border-radius: 0 0 16px 16px;
     color: #333;
@@ -403,7 +405,7 @@ button#stats-btn {
 .strategy-link {
     background: white;
     border: 2px solid #e9ecef;
-    font-family: 'Press Start 2P', monospace;
+    font-family: 'Nunito', sans-serif;
     font-size: 0.82rem;
     padding: 18.75px;
     width: 100%;
@@ -435,7 +437,7 @@ button#stats-btn {
 .hint-link {
     background: transparent;
     border: none;
-    font-family: 'Press Start 2P', monospace;
+    font-family: 'Nunito', sans-serif;
     font-size: 0.82rem;
     padding: 18.75px;
     width: 100%;
@@ -510,7 +512,7 @@ button#stats-btn {
     border: none;
     padding: 12px 25px;
     border-radius: 15px;
-    font-family: 'Press Start 2P', monospace;
+    font-family: 'Nunito', sans-serif;
     font-size: 0.8rem;
     cursor: pointer;
     transition: background-color 0.2s;
@@ -527,7 +529,7 @@ button#stats-btn {
     border: none;
     padding: 15px 25px;
     border-radius: 12px;
-    font-family: 'Press Start 2P', monospace;
+    font-family: 'Nunito', sans-serif;
     font-size: 0.7rem;
     cursor: pointer;
     transition: background-color 0.2s;
@@ -568,7 +570,7 @@ button#stats-btn {
     font-size: 0.835rem;
     text-align: center;
     border: none;
-    font-family: 'Press Start 2P', monospace;
+    font-family: 'Nunito', sans-serif;
     line-height: normal;
     max-height: 48px;
 }
@@ -587,7 +589,7 @@ button#stats-btn {
     align-items: center;
     justify-content: center;
     font-size: 1rem;
-    font-family: 'Press Start 2P', monospace;
+    font-family: 'Nunito', sans-serif;
     cursor: pointer;
     transition: transform 0.2s;
 }
@@ -737,7 +739,7 @@ button#stats-btn {
     background: none;
     border: none;
     font-size: 0.8rem;
-    font-family: 'Press Start 2P', monospace;
+    font-family: 'Nunito', sans-serif;
     outline: none;
     width: 100%;
     padding: 19.5px 15px 14.5px 15px;
@@ -757,7 +759,7 @@ button#stats-btn {
     border: 0;
     color: #333;
     font-size: 0.8rem;
-    font-family: 'Press Start 2P', monospace;
+    font-family: 'Nunito', sans-serif;
     outline: none;
     text-align: center;
     display: none;
@@ -785,7 +787,7 @@ button#stats-btn {
     border-radius: 10px;
     padding: 8px 8px;
     color: #333;
-    font-family: 'Press Start 2P', monospace;
+    font-family: 'Nunito', sans-serif;
     font-size: 0.7rem;
     cursor: pointer;
 }
@@ -856,7 +858,7 @@ button#stats-btn {
     border: 0;
     color: #333;
     font-size: 0.8rem;
-    font-family: 'Press Start 2P', monospace;
+    font-family: 'Nunito', sans-serif;
     text-align: center;
     display: none;
     cursor: pointer;
@@ -887,7 +889,7 @@ button#stats-btn {
     display: none;
     flex-direction: column;
     overflow: hidden;
-    font-family: 'Press Start 2P', monospace;
+    font-family: 'Nunito', sans-serif;
     z-index: 1000;
 }
 
@@ -901,7 +903,7 @@ button#stats-btn {
     border: none;
     color: #333;
     font-size: 0.8rem;
-    font-family: 'Press Start 2P', monospace;
+    font-family: 'Nunito', sans-serif;
     cursor: pointer;
     position: relative;
     text-align: left;
@@ -928,7 +930,7 @@ button#stats-btn {
     border: none;
     padding: 8px 12px;
     border-radius: 12px;
-    font-family: 'Press Start 2P', monospace;
+    font-family: 'Nunito', sans-serif;
     font-size: 0.8rem;
     cursor: pointer;
     transition: background-color 0.2s;
@@ -1019,7 +1021,7 @@ button#stats-btn {
     color: #333;
     border: none;
     padding: 14px 16px;
-    font-family: 'Press Start 2P', monospace;
+    font-family: 'Nunito', sans-serif;
     font-size: 0.85rem;
     display: flex;
     align-items: center;
@@ -1048,7 +1050,7 @@ button#stats-btn {
     border: none;
     padding: 15px 25px;
     border-radius: 12px;
-    font-family: 'Press Start 2P', monospace;
+    font-family: 'Nunito', sans-serif;
     font-size: 0.7rem;
     cursor: pointer;
     margin-top: 10px;
@@ -1208,7 +1210,7 @@ button#stats-btn {
     background: none;
     border: 2px solid #eaecf0;
     border-radius: 15px;
-    font-family: 'Press Start 2P', monospace;
+    font-family: 'Nunito', sans-serif;
     font-size: 0.8rem;
     padding: 18.5px 15px;
     outline: none;
@@ -1316,7 +1318,7 @@ button#stats-btn {
 
 .primary-action,
 .secondary-action {
-    font-family: 'Press Start 2P', monospace;
+    font-family: 'Nunito', sans-serif;
     border-radius: 14px;
     cursor: pointer;
     transition: transform 0.15s ease, box-shadow 0.15s ease;
@@ -1458,7 +1460,7 @@ button.calendar-cell {
     display: flex;
     align-items: center;
     justify-content: center;
-    font-family: 'Press Start 2P', monospace;
+    font-family: 'Nunito', sans-serif;
     font-size: 0.68rem;
     background: #fff;
     color: #0f172a;
@@ -1646,7 +1648,6 @@ button.calendar-cell:disabled {
         background: #fff;
     }
     body {
-        background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32' width='32' height='32' fill='none' stroke='rgb(15 23 42 / 0.04)'%3e%3cpath d='M0 .5H31.5V32'/%3e%3c/svg%3e");
         padding: 0px 18px;
     }
     body.no-scroll {
@@ -1699,7 +1700,7 @@ button.calendar-cell:disabled {
         padding: 25.75px 12px 16px 0;
         font-size: 0.78rem;
         height: 63px;
-        font-family: 'Press Start 2P', monospace;
+        font-family: 'Nunito', sans-serif;
     }
     .source-btn {
         font-size: 0.78rem;

--- a/styles.css
+++ b/styles.css
@@ -1227,56 +1227,71 @@ button#stats-btn {
 }
 
 .daily-challenge-card {
-    border: 2px solid #e9ecef;
+    --card-accent: #e9ecef;
+    border: 4px solid var(--card-accent);
     border-radius: 18px;
-    padding: 20px;
+    padding: 24px;
     display: flex;
     flex-direction: column;
     gap: 18px;
     background: #fff;
     text-align: left;
+    position: relative;
+}
+
+.daily-challenge-card--ready {
+    --card-accent: #1cb0f6;
+}
+
+.daily-challenge-card--won {
+    --card-accent: #15803d;
+}
+
+.daily-challenge-card--lost {
+    --card-accent: #b91c1c;
+}
+
+.daily-challenge-card--ready .daily-challenge-date-badge,
+.daily-challenge-card--won .daily-challenge-date-badge,
+.daily-challenge-card--lost .daily-challenge-date-badge {
+    color: #fff;
+}
+
+.daily-challenge-date-badge {
+    position: absolute;
+    top: -4px;
+    right: -4px;
+    background: var(--card-accent);
+    color: #0f172a;
+    font-size: 0.75rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    padding: 6px 12px;
+    border-radius: 0 14px 0 12px;
+}
+
+.daily-challenge-date-badge:empty {
+    display: none;
 }
 
 .daily-challenge-header {
     display: flex;
-    justify-content: space-between;
-    align-items: baseline;
+    align-items: center;
 }
 
 .daily-challenge-header h3 {
-    font-size: 0.85rem;
+    font-size: 15px;
     text-transform: uppercase;
-    letter-spacing: 1px;
-}
-
-.daily-challenge-date {
-    font-size: 0.65rem;
-    color: #64748b;
-    text-transform: uppercase;
+    color: #afafaf;
+    letter-spacing: 0.08em;
 }
 
 .daily-challenge-body {
     display: flex;
-    gap: 18px;
-    align-items: center;
-}
-
-.daily-challenge-image {
-    width: 76px;
-    height: 76px;
-    border-radius: 14px;
-    border: 2px solid #e9ecef;
-    background: #f8fafc;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    overflow: hidden;
-}
-
-.daily-challenge-image img {
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
+    flex-direction: column;
+    gap: 12px;
+    align-items: flex-start;
 }
 
 .daily-challenge-question {
@@ -1535,13 +1550,8 @@ button.calendar-cell:disabled {
     }
 
     .daily-challenge-body {
-        flex-direction: column;
         align-items: flex-start;
-    }
-
-    .daily-challenge-image {
-        width: 68px;
-        height: 68px;
+        gap: 10px;
     }
 
     .daily-challenge-question {

--- a/styles.css
+++ b/styles.css
@@ -1254,10 +1254,6 @@ button#stats-btn {
     font-weight: 500;
 }
 
-.welcome-info-card .secondary-action {
-    align-self: flex-start;
-}
-
 .daily-challenge-card {
     --card-accent: #e9ecef;
     --primary-action-bg: var(--card-accent);
@@ -1633,10 +1629,6 @@ button.calendar-cell:disabled {
     }
 
     .daily-challenge-card {
-        padding: 20px;
-    }
-
-    .welcome-info-card {
         padding: 20px;
     }
 }

--- a/styles.css
+++ b/styles.css
@@ -34,6 +34,53 @@ main {
     display: block;
 }
 
+.info-view {
+    max-width: 720px;
+    margin: 32px auto 48px;
+    background: rgba(255, 255, 255, 0.97);
+    border: 2px solid #e9ecef;
+    border-radius: 22px;
+    padding: 28px 32px;
+    box-shadow: 0 18px 35px rgba(15, 23, 42, 0.08);
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+}
+
+.view-header {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.view-header h2 {
+    font-size: 0.95rem;
+}
+
+.back-button {
+    background: #fff;
+    border: 2px solid #e9ecef;
+    border-radius: 12px;
+    padding: 10px 14px;
+    font-family: 'Press Start 2P', monospace;
+    font-size: 0.6rem;
+    color: #0f172a;
+    cursor: pointer;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    transition: background-color 0.2s ease, border-color 0.2s ease;
+}
+
+.back-button:hover {
+    background-color: rgba(15, 23, 42, 0.08);
+    border-color: #d4d8dd;
+}
+
+.back-button:focus-visible {
+    outline: 2px solid #0f172a;
+    outline-offset: 2px;
+}
+
 .game-container {
     max-width: 500px;
     margin: 0 auto;
@@ -1101,43 +1148,36 @@ button#stats-btn {
 
 /* Comments section */
 .comments-section {
-    display: none;
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background: #fff;
-    z-index: 1000;
-    flex-direction: column;
-    border-radius: 18px;
+    padding: 0 0 48px;
 }
 
-.comments-section.open {
-    display: flex;
+.comments-section.view.active {
+    display: block;
 }
 
-.comments-header {
-    display: flex;
-    align-items: center;
-    gap: 12px;
-    padding: 16px 20px;
+.comments-view {
+    gap: 0;
+}
+
+.comments-view .view-header {
+    padding-bottom: 16px;
     border-bottom: 1px solid #e9ecef;
+    margin-bottom: 0;
 }
 
-.comments-header h2 {
+.comments-view .view-header h2 {
     font-size: 0.9375rem;
 }
 
 .comments-list {
     flex: 1;
     overflow-y: auto;
-    padding: 20px;
+    padding: 24px 0;
 }
 
 .comment {
     margin-bottom: 12px;
-    padding-bottom: 12px;
+    padding: 0 0 12px 0;
     border-bottom: 1px solid #e9ecef;
     font-size: 0.8rem;
 }
@@ -1154,7 +1194,7 @@ button#stats-btn {
 }
 
 .comments-input {
-    padding: 20px;
+    padding: 20px 0 0 0;
     border-top: 1px solid #e9ecef;
     display: flex;
     gap: 10px;
@@ -1323,10 +1363,14 @@ button#stats-btn {
     box-shadow: 0 18px 35px rgba(15, 23, 42, 0.08);
 }
 
+.calendar-wrapper .view-header {
+    justify-content: flex-start;
+    margin-bottom: 16px;
+}
+
 .calendar-title {
     font-size: 0.95rem;
-    text-align: center;
-    margin-bottom: 10px;
+    margin: 0;
 }
 
 .calendar-subtitle {
@@ -1608,6 +1652,23 @@ button.calendar-cell:disabled {
     body.no-scroll {
         overflow: hidden;
     }
+    .info-view {
+        margin: 20px auto 32px;
+        padding: 24px 20px;
+        border-radius: 18px;
+    }
+    .view-header h2 {
+        font-size: 0.85rem;
+    }
+    .back-button {
+        font-size: 0.52rem;
+        padding: 9px 12px;
+    }
+    .calendar-wrapper .view-header {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 12px;
+    }
     .game-header {
         padding: 18px 0;
     }
@@ -1651,11 +1712,7 @@ button.calendar-cell:disabled {
         width: 70px;
     }
     .comments-section {
-        position: fixed;
-        left: 0;
-        bottom: 0;
-        border-radius: 18px 18px 0 0;
-        box-shadow: 0 -2px 10px rgba(0,0,0,0.1);
+        padding-bottom: 32px;
     }
 
     main {

--- a/styles.css
+++ b/styles.css
@@ -1223,14 +1223,14 @@ button#stats-btn {
     text-align: center;
     display: flex;
     flex-direction: column;
-    gap: 26px;
+    gap: 20px;
 }
 
 .welcome-info-card {
     background: #fff;
     border: 2px solid #e9ecef;
     border-radius: 18px;
-    padding: 24px;
+    padding: 20px;
     display: flex;
     flex-direction: column;
     gap: 18px;
@@ -1248,18 +1248,13 @@ button#stats-btn {
 }
 
 .welcome-info-note {
-    font-size: 0.95rem;
-    color: #64748b;
-    line-height: 1.55;
+    font-size: 17px;
+    color: #777;
+    line-height: 24px;
+    font-weight: 500;
 }
 
-.welcome-info-actions {
-    display: flex;
-    justify-content: flex-start;
-    align-items: flex-start;
-}
-
-.welcome-info-actions .secondary-action {
+.welcome-info-card .secondary-action {
     align-self: flex-start;
 }
 
@@ -1339,7 +1334,7 @@ button#stats-btn {
 .daily-challenge-question {
     font-size: 21px;
     line-height: 28px;
-    color: #0f172a;
+    color: #4b4b4b;
     font-weight: 700;
 }
 

--- a/styles.css
+++ b/styles.css
@@ -1220,25 +1220,10 @@ button#stats-btn {
 .welcome-content {
     max-width: 520px;
     margin: 40px auto;
-    background: rgba(255, 255, 255, 0.95);
-    border: 2px solid #e9ecef;
-    border-radius: 22px;
-    padding: 32px 28px;
     text-align: center;
     display: flex;
     flex-direction: column;
     gap: 26px;
-    box-shadow: 0 18px 35px rgba(15, 23, 42, 0.08);
-}
-
-.welcome-title {
-    font-size: 1rem;
-}
-
-.welcome-subtitle {
-    font-size: 0.75rem;
-    line-height: 1.6;
-    color: #4b5563;
 }
 
 .daily-challenge-card {
@@ -1306,6 +1291,12 @@ button#stats-btn {
     margin-top: 6px;
     text-transform: uppercase;
     letter-spacing: 1px;
+}
+
+.daily-challenge-actions {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
 }
 
 .daily-challenge-status.status-won {
@@ -1538,15 +1529,6 @@ button.calendar-cell:disabled {
 @media (max-width: 768px) {
     .welcome-content {
         margin: 32px auto;
-        padding: 28px 22px;
-    }
-
-    .welcome-title {
-        font-size: 0.9rem;
-    }
-
-    .welcome-subtitle {
-        font-size: 0.68rem;
     }
 
     .daily-challenge-body {

--- a/styles.css
+++ b/styles.css
@@ -1234,7 +1234,7 @@ button#stats-btn {
     padding: 20px;
     display: flex;
     flex-direction: column;
-    gap: 18px;
+    gap: 8px;
     text-align: left;
 }
 
@@ -1297,7 +1297,7 @@ button#stats-btn {
     top: -4px;
     right: -4px;
     background: var(--card-accent);
-    color: #0f172a;
+    color: #fff;
     font-size: 15px;
     font-weight: 700;
     text-transform: uppercase;
@@ -1348,12 +1348,9 @@ button#stats-btn {
     gap: 12px;
 }
 
-.daily-challenge-status.status-won {
-    color: #15803d;
-}
-
+.daily-challenge-status.status-won,
 .daily-challenge-status.status-lost {
-    color: #b91c1c;
+    color: var(--card-accent);
 }
 
 .primary-action,
@@ -1406,13 +1403,8 @@ button#stats-btn {
 }
 
 .calendar-wrapper {
-    max-width: 900px;
-    margin: 40px auto;
-    background: rgba(255, 255, 255, 0.97);
-    border: 2px solid #e9ecef;
-    border-radius: 22px;
-    padding: 28px 32px 36px;
-    box-shadow: 0 18px 35px rgba(15, 23, 42, 0.08);
+    max-width: 520px;
+    margin: 0 auto;
 }
 
 .calendar-wrapper .view-header {
@@ -1589,11 +1581,6 @@ button.calendar-cell:disabled {
     .daily-challenge-body {
         align-items: flex-start;
         gap: 10px;
-    }
-
-    .calendar-wrapper {
-        padding: 24px 20px 30px;
-        margin: 28px auto 48px;
     }
 
     .calendar-grid {

--- a/styles.css
+++ b/styles.css
@@ -148,9 +148,10 @@ main {
 }
 
 .game-title {
-    font-size: 0.9375rem;
-    width: 150px;
-    font-weight: 400;
+    font-size: 1.1rem;
+    width: 100px;
+    font-weight: 650;
+    line-height: 1.2;
 }
 
 .icon-button {
@@ -1219,7 +1220,7 @@ button#stats-btn {
 
 .welcome-content {
     max-width: 520px;
-    margin: 40px auto;
+    margin: 0 auto;
     text-align: center;
     display: flex;
     flex-direction: column;

--- a/styles.css
+++ b/styles.css
@@ -37,13 +37,9 @@ main {
 }
 
 .info-view {
-    max-width: 720px;
-    margin: 32px auto 48px;
-    background: rgba(255, 255, 255, 0.97);
-    border: 2px solid #e9ecef;
+    max-width: 520px;
+    margin: 0 auto;
     border-radius: 22px;
-    padding: 28px 32px;
-    box-shadow: 0 18px 35px rgba(15, 23, 42, 0.08);
     display: flex;
     flex-direction: column;
     gap: 24px;
@@ -995,14 +991,6 @@ button#stats-btn {
     font-size: 0.8rem;
 }
 
-/* Accordion inside Source modal */
-.accordion {
-    text-align: left;
-    max-height: calc(90vh - 220px);
-    overflow-y: auto;
-    margin: 16px 0;
-}
-
 .accordion-item {
     border: 2px solid #e9ecef;
     border-radius: 12px;
@@ -1587,10 +1575,6 @@ button.calendar-cell:disabled {
 }
 
 @media (max-width: 768px) {
-    .welcome-content {
-        margin: 32px auto;
-    }
-
     .daily-challenge-body {
         align-items: flex-start;
         gap: 10px;
@@ -1675,11 +1659,6 @@ button.calendar-cell:disabled {
     }
     body.no-scroll {
         overflow: hidden;
-    }
-    .info-view {
-        margin: 20px auto 32px;
-        padding: 24px 20px;
-        border-radius: 18px;
     }
     .view-header h2 {
         font-size: 0.85rem;

--- a/styles.css
+++ b/styles.css
@@ -1011,21 +1011,29 @@ button#stats-btn {
     width: 100%;
     text-align: left;
     background: #fff;
-    color: #333;
+    color: #4b4b4b;
     border: none;
     padding: 14px 16px;
     font-family: 'Nunito', sans-serif;
-    font-size: 0.85rem;
+    font-size: 19px;
+    font-weight: 700;
     display: flex;
     align-items: center;
     justify-content: space-between;
     cursor: pointer;
-    line-height: 1.4;
 }
 
 .accordion-panel {
     padding: 2px 16px 10px;
     display: none;
+}
+
+.accordion-panel p {
+    color: #777;
+    font-size: 17px;
+    line-height: 24px;
+    font-weight: 500;
+    margin-bottom: 6px;
 }
 
 .accordion-item.open .accordion-panel {
@@ -1278,9 +1286,9 @@ button#stats-btn {
 }
 
 .daily-challenge-card--lost {
-    --card-accent: #b91c1c;
+    --card-accent: #ff4b4c;
     --primary-action-bg: var(--card-accent);
-    --primary-action-shadow: var(--card-accent);
+    --primary-action-shadow: #cd3d3d;
     --primary-action-text: #fff;
 }
 
@@ -1289,7 +1297,7 @@ button#stats-btn {
     top: -4px;
     right: -4px;
     background: var(--card-accent);
-    color: #fff;
+    color: #0f172a;
     font-size: 15px;
     font-weight: 700;
     text-transform: uppercase;
@@ -1310,7 +1318,6 @@ button#stats-btn {
     font-size: 15px;
     text-transform: uppercase;
     color: #afafaf;
-    letter-spacing: 0.08em;
 }
 
 .daily-challenge-body {

--- a/styles.css
+++ b/styles.css
@@ -55,6 +55,10 @@ main {
     font-size: 0.95rem;
 }
 
+.game-view-header {
+    margin-bottom: 16px;
+}
+
 .back-button {
     background: #fff;
     border: 2px solid #e9ecef;

--- a/styles.css
+++ b/styles.css
@@ -1310,9 +1310,13 @@ button#stats-btn {
 .primary-action,
 .secondary-action {
     font-family: 'Nunito', sans-serif;
-    border-radius: 14px;
+    border-radius: 16px;
     cursor: pointer;
     transition: transform 0.15s ease, box-shadow 0.15s ease;
+    text-transform: uppercase;
+    letter-spacing: 0.05rem;
+    font-size: 15px;
+    font-weight: 700;
 }
 
 .primary-action {
@@ -1320,7 +1324,6 @@ button#stats-btn {
     color: #fff;
     padding: 16px 18px;
     border: none;
-    font-size: 0.72rem;
     box-shadow: 0 10px 18px rgba(15, 23, 42, 0.18);
 }
 
@@ -1335,15 +1338,15 @@ button#stats-btn {
 }
 
 .secondary-action {
-    background: transparent;
-    border: 2px solid #0f172a;
-    color: #0f172a;
-    padding: 14px 16px;
-    font-size: 0.62rem;
+    background: #fff;
+    border: 2px solid #eaecef;
+    color: #838181;
+    padding: 11.25px 18px;
+    box-shadow: 0 2px 0 #eaecef;
 }
 
 .secondary-action:hover {
-    background: rgba(15, 23, 42, 0.08);
+    background: rgba(15, 23, 42, 0.03);
 }
 
 .calendar-wrapper {
@@ -1543,16 +1546,6 @@ button.calendar-cell:disabled {
 
     .daily-challenge-question {
         font-size: 0.78rem;
-    }
-
-    .primary-action {
-        font-size: 0.65rem;
-        padding: 14px 16px;
-    }
-
-    .secondary-action {
-        font-size: 0.58rem;
-        padding: 12px 14px;
     }
 
     .calendar-wrapper {

--- a/styles.css
+++ b/styles.css
@@ -1241,7 +1241,8 @@ button#stats-btn {
 .welcome-info-body {
     display: flex;
     flex-direction: column;
-    gap: 12px;
+    gap: 6px;
+    margin-bottom: 8px;
 }
 
 .welcome-info-body p {
@@ -1265,7 +1266,7 @@ button#stats-btn {
     padding: 20px;
     display: flex;
     flex-direction: column;
-    gap: 18px;
+    gap: 8px;
     background: #fff;
     text-align: left;
     position: relative;
@@ -1325,6 +1326,13 @@ button#stats-btn {
     flex-direction: column;
     gap: 12px;
     align-items: flex-start;
+}
+
+.daily-challenge-text {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    margin-bottom: 8px;
 }
 
 .daily-challenge-question {


### PR DESCRIPTION
## Summary
- replace the help, per-question source/stats, and comments modals with dedicated views that include back navigation and add a back button to the calendar page
- add client-side view navigation helpers so these pages open and close cleanly from their callers
- update styling to support the new view layouts and shared back button treatment

## Testing
- node --check script.js

------
https://chatgpt.com/codex/tasks/task_e_68cd1f5126a88329afe1d74f192aebac