### PR TITLE
Show Supabase guess distribution in placeholders

### DIFF
--- a/index.html
+++ b/index.html
@@ -145,7 +145,7 @@
                     <input
                         type="text"
                         id="guess-input"
-                        placeholder="Enter a guess..."
+                        placeholder="Enter first guess"
                         inputmode="numeric"
                         pattern="[0-9,]*"
                     >

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
     <meta name="description" content="A Wordle-style game for Fermi questions. Guess the answer to estimation questions in 6 or less tries.">
     <link rel="canonical" href="https://www.fermiquestions.org">
     <link rel="stylesheet" href="styles.css">
-    <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Nunito:ital,wght@0,200..1000;1,200..1000&family=Open+Sans:wght@400;500&family=Varela+Round&display=swap" rel="stylesheet">
     <script defer data-domain="fermiquestions.org" data-api="https://fermiquestions.daniel-fetz.workers.dev/fermiquestions/event" src="https://fermiquestions.daniel-fetz.workers.dev/fermiquestions/script.hash.js"></script>
     <!-- Supabase client library -->
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
@@ -35,30 +35,40 @@
     <main>
         <section id="welcome-screen" class="view active">
             <div class="welcome-content">
-                <h2 class="welcome-title">Welcome to Fermi Questions</h2>
-                <p class="welcome-subtitle">Sharpen your estimation skills with a fresh puzzle every day.</p>
-                <div class="daily-challenge-card">
+                <div class="daily-challenge-card" id="daily-challenge-card">
+                    <span id="daily-challenge-date" class="daily-challenge-date-badge"></span>
                     <div class="daily-challenge-header">
                         <h3>Daily Challenge</h3>
-                        <span id="daily-challenge-date" class="daily-challenge-date"></span>
                     </div>
                     <div class="daily-challenge-body">
-                        <div class="daily-challenge-image" id="daily-challenge-image-container" style="display: none;">
-                            <img id="daily-challenge-image" alt="" />
-                        </div>
                         <div class="daily-challenge-text">
                             <p id="daily-challenge-question" class="daily-challenge-question"></p>
                             <p id="daily-challenge-status" class="daily-challenge-status"></p>
                         </div>
                     </div>
-                    <button id="play-daily-btn" class="primary-action">Play</button>
+                    <div class="daily-challenge-actions">
+                        <button id="play-daily-btn" class="primary-action">Play</button>
+                        <button id="calendar-link-btn" class="secondary-action">Previous days</button>
+                    </div>
                 </div>
-                <button id="calendar-link-btn" class="secondary-action">Browse the calendar</button>
+                <div class="welcome-info-card">
+                    <div class="daily-challenge-header">
+                        <h3>How to Play</h3>
+                    </div>
+                    <div class="welcome-info-body">
+                        <p class="daily-challenge-question welcome-info-lede">Fermi estimates. Probability calibration training. Bayesian updating.</p>
+                        <p class="welcome-info-note">Many daunting terms, but this game effectively trains some of the core rationality techniques.</p>
+                    </div>
+                    <button id="learn-more-btn" class="secondary-action">Learn more</button>
+                </div>
             </div>
         </section>
 
         <section id="game-view" class="view">
             <div class="game-container">
+                <div class="view-header game-view-header">
+                    <button type="button" class="back-button" id="game-back-btn">Back</button>
+                </div>
         <!-- Question Display -->
         <div class="question-container">
             <div class="question-box">
@@ -85,19 +95,6 @@
                     <span id="comment-count">0</span>
                 </button>
                 <button id="source-btn" class="source-btn">Source & Stats <span class="arrow">></span></button>
-            </div>
-        </div>
-
-        <!-- Comments Section -->
-        <div class="comments-section" id="comments-section">
-            <div class="comments-header">
-                <button class="icon-button" id="comments-back-btn">&lt;</button>
-                <h2>Comments</h2>
-            </div>
-            <div class="comments-list" id="comments-list"></div>
-            <div class="comments-input">
-                <textarea id="comment-input" placeholder="Add a comment..."></textarea>
-                <button id="comment-submit-btn" class="submit-btn">Post</button>
             </div>
         </div>
 
@@ -209,10 +206,25 @@
             </div>
         </div>
 
-        <!-- Help Modal -->
-        <div class="modal" id="help-modal">
-            <div class="modal-content">
-                <h2>How to Play</h2>
+            </div>
+        </section>
+
+        <section id="calendar-view" class="view">
+            <div class="calendar-wrapper">
+                <div class="view-header">
+                    <button type="button" class="back-button" id="calendar-back-btn">&lt; Back</button>
+                    <h2 class="calendar-title">Question Calendar</h2>
+                </div>
+                <div id="calendar-months" class="calendar-months"></div>
+            </div>
+        </section>
+
+        <section id="help-view" class="view">
+            <div class="info-view">
+                <div class="view-header">
+                    <button type="button" class="back-button" id="help-back-btn">&lt; Back</button>
+                    <h2>How to Play</h2>
+                </div>
                 <div class="accordion" id="help-accordion">
                     <div class="accordion-item" id="acc-calibration-help-item">
                         <button class="accordion-header" id="acc-calibration-help-header" aria-expanded="false" aria-controls="acc-calibration-help-panel">
@@ -249,15 +261,15 @@
                         </div>
                     </div>
                 </div>
-                <button id="close-help-btn" class="close-btn">Close</button>
             </div>
-        </div>
+        </section>
 
-
-        <!-- Source/Explanation Modal -->
-        <div class="modal" id="source-modal">
-            <div class="modal-content">
-                <h2>Source & Stats</h2>
+        <section id="source-view" class="view">
+            <div class="info-view">
+                <div class="view-header">
+                    <button type="button" class="back-button" id="source-back-btn">&lt; Back</button>
+                    <h2>Source & Stats</h2>
+                </div>
                 <div class="accordion" id="source-accordion">
                     <div class="accordion-item" id="acc-source-item">
                         <button class="accordion-header" id="acc-source-header" aria-expanded="false" aria-controls="acc-source-panel">
@@ -303,14 +315,15 @@
                         </div>
                     </div>
                 </div>
-                <button id="close-source-btn" class="close-btn">Close</button>
             </div>
-        </div>
+        </section>
 
-        <!-- Stats Modal -->
-        <div class="modal" id="stats-modal">
-            <div class="modal-content">
-                <h2>Statistics</h2>
+        <section id="stats-view" class="view">
+            <div class="info-view">
+                <div class="view-header">
+                    <button type="button" class="back-button" id="stats-back-btn">&lt; Back</button>
+                    <h2>Statistics</h2>
+                </div>
                 <div class="accordion" id="stats-accordion">
                     <div class="accordion-item open" id="acc-statsgrid-item">
                         <button class="accordion-header" id="acc-statsgrid-header" aria-expanded="true" aria-controls="acc-statsgrid-panel">
@@ -425,22 +438,20 @@
                 </div>
 
                 <button id="share-stats-btn" class="share-btn">Share</button>
-                <button id="close-stats-btn" class="close-btn">Close</button>
-            </div>
-        </div>
             </div>
         </section>
 
-        <section id="calendar-view" class="view">
-            <div class="calendar-wrapper">
-                <h2 class="calendar-title">Question Calendar</h2>
-                <p class="calendar-subtitle">Pick a day to play or review its challenge.</p>
-                <div class="calendar-legend">
-                    <span><span class="legend-box pending"></span> Not played</span>
-                    <span><span class="legend-box won"></span> Completed</span>
-                    <span><span class="legend-box lost"></span> Missed</span>
+        <section id="comments-section" class="view comments-section">
+            <div class="info-view comments-view">
+                <div class="view-header">
+                    <button type="button" class="back-button" id="comments-back-btn">&lt; Back</button>
+                    <h2>Comments</h2>
                 </div>
-                <div id="calendar-months" class="calendar-months"></div>
+                <div class="comments-list" id="comments-list"></div>
+                <div class="comments-input">
+                    <textarea id="comment-input" placeholder="Add a comment..."></textarea>
+                    <button id="comment-submit-btn" class="submit-btn">Post</button>
+                </div>
             </div>
         </section>
     </main>

--- a/script.js
+++ b/script.js
@@ -1873,10 +1873,8 @@ function clearGuesses() {
         const guessField = document.createElement('div');
         guessField.className = 'guess-field empty';
 
-        // Set the appropriate text for each guess position
         const guessNumber = i + 1;
-        const guessText = getGuessPlaceholderText(guessNumber);
-        guessField.textContent = guessText;
+        setGuessPlaceholderContent(guessField, guessNumber);
 
         const feedbackButton = document.createElement('button');
         feedbackButton.className = 'feedback-button hidden';
@@ -1900,18 +1898,51 @@ function formatGuessPercentage(value) {
     return String(rounded).replace(/\.0$/, '');
 }
 
-function getGuessPlaceholderText(guessNumber) {
-    const baseText = getGuessText(guessNumber);
+function getGuessPlaceholderInfo(guessNumber) {
+    const label = getGuessText(guessNumber);
     const distribution = currentQuestionGuessDistribution;
 
     if (!distribution || !distribution.entries || distribution.totalCompleted <= 0) {
-        return baseText;
+        return { label, percentageText: null };
     }
 
     const entry = distribution.entries[guessNumber];
     const percentage = entry && Number.isFinite(entry.percentage) ? entry.percentage : 0;
     const formatted = formatGuessPercentage(percentage);
-    return `${baseText} · ${formatted}% of players`;
+
+    return {
+        label,
+        percentageText: `${formatted}% of players`
+    };
+}
+
+function setGuessPlaceholderContent(guessField, guessNumber) {
+    if (!guessField) return;
+
+    const { label, percentageText } = getGuessPlaceholderInfo(guessNumber);
+
+    let labelEl = guessField.querySelector('.guess-placeholder-text');
+    let percentageEl = guessField.querySelector('.guess-placeholder-percentage');
+
+    if (!labelEl || !percentageEl) {
+        guessField.innerHTML = '';
+        labelEl = document.createElement('span');
+        labelEl.className = 'guess-placeholder-text';
+        percentageEl = document.createElement('div');
+        percentageEl.className = 'guess-placeholder-percentage';
+        guessField.appendChild(labelEl);
+        guessField.appendChild(percentageEl);
+    }
+
+    labelEl.textContent = label;
+
+    if (percentageText) {
+        percentageEl.textContent = percentageText;
+        percentageEl.classList.remove('hidden');
+    } else {
+        percentageEl.textContent = '';
+        percentageEl.classList.add('hidden');
+    }
 }
 
 function applyGuessPlaceholderTexts() {
@@ -1921,7 +1952,7 @@ function applyGuessPlaceholderTexts() {
         const guessField = row.querySelector('.guess-field');
         if (!guessField || !guessField.classList.contains('empty')) return;
         const guessNumber = index + 1;
-        guessField.textContent = getGuessPlaceholderText(guessNumber);
+        setGuessPlaceholderContent(guessField, guessNumber);
     });
 }
 

--- a/script.js
+++ b/script.js
@@ -1168,6 +1168,14 @@ const correctAnswer = document.getElementById('correct-answer');
 const guessesContainer = document.getElementById('guesses-container');
 let guessHeaderCountEl = null;
 const guessInput = document.getElementById('guess-input');
+const guessInputPlaceholderTexts = [
+    'Enter first guess',
+    'Enter second guess',
+    'Enter third guess',
+    'Enter fourth guess',
+    'Enter fifth guess',
+    'Enter final guess'
+];
 const confidenceInput = document.getElementById('confidence-input');
 const confidenceButton = document.getElementById('confidence-button');
 const confidenceMenu = document.getElementById('confidence-menu');
@@ -1901,12 +1909,41 @@ function clearGuesses() {
         guessRow.appendChild(feedbackButton);
         guessesContainer.appendChild(guessRow);
     }
+
+    refreshGuessUIState();
 }
 
 function updateGuessUsageDisplay() {
     if (!guessHeaderCountEl) return;
     const usedGuesses = Math.min(Math.max(currentGuess, 0), maxGuesses);
     guessHeaderCountEl.textContent = `${usedGuesses} out of ${maxGuesses}`;
+}
+
+function updateGuessInputPlaceholder() {
+    if (!guessInput) return;
+    const index = Math.min(Math.max(currentGuess, 0), guessInputPlaceholderTexts.length - 1);
+    guessInput.placeholder = guessInputPlaceholderTexts[index];
+}
+
+function updateActiveGuessField() {
+    if (!guessesContainer) return;
+    const guessRows = guessesContainer.querySelectorAll('.guess-row');
+    const highlightIndex = !gameOver && currentGuess < maxGuesses ? currentGuess : -1;
+
+    guessRows.forEach((row, index) => {
+        const guessField = row.querySelector('.guess-field');
+        if (!guessField) return;
+        if (index === highlightIndex) {
+            guessField.classList.add('active');
+        } else {
+            guessField.classList.remove('active');
+        }
+    });
+}
+
+function refreshGuessUIState() {
+    updateGuessInputPlaceholder();
+    updateActiveGuessField();
 }
 
 function formatGuessPercentage(value) {
@@ -2123,6 +2160,7 @@ function submitGuess() {
         endGame();
     }
 
+    refreshGuessUIState();
     resetConfidenceInput();
     // Hide confidence input after first guess if needed
     updateConfidenceInputVisibility();
@@ -2138,6 +2176,7 @@ function addGuessToDisplay(guess) {
     guessField.textContent = formatNumber(guess);
     guessField.classList.remove('empty');
     updateGuessUsageDisplay();
+    refreshGuessUIState();
 }
 
 // Show feedback for a guess
@@ -3200,6 +3239,7 @@ function restoreGuessesDisplay(savedGuesses) {
 
     updateGuessUsageDisplay();
     applyGuessPlaceholderTexts();
+    refreshGuessUIState();
 }
 
 // Update display elements for ended game (without updating stats)

--- a/script.js
+++ b/script.js
@@ -1166,6 +1166,7 @@ const resultMessage = document.getElementById('result-message');
 const resultEmoji = document.getElementById('result-emoji');
 const correctAnswer = document.getElementById('correct-answer');
 const guessesContainer = document.getElementById('guesses-container');
+let guessHeaderCountEl = null;
 const guessInput = document.getElementById('guess-input');
 const confidenceInput = document.getElementById('confidence-input');
 const confidenceButton = document.getElementById('confidence-button');
@@ -1865,6 +1866,23 @@ function renderCalendar() {
 function clearGuesses() {
     guessesContainer.innerHTML = '';
 
+    const guessHeader = document.createElement('div');
+    guessHeader.className = 'guess-header';
+
+    const headerTitle = document.createElement('span');
+    headerTitle.className = 'guess-header-title';
+    headerTitle.textContent = 'Guesses';
+
+    const headerCount = document.createElement('span');
+    headerCount.className = 'guess-header-count';
+
+    guessHeader.appendChild(headerTitle);
+    guessHeader.appendChild(headerCount);
+    guessesContainer.appendChild(guessHeader);
+
+    guessHeaderCountEl = headerCount;
+    updateGuessUsageDisplay();
+
     // Create empty guess rows
     for (let i = 0; i < maxGuesses; i++) {
         const guessRow = document.createElement('div');
@@ -1883,6 +1901,12 @@ function clearGuesses() {
         guessRow.appendChild(feedbackButton);
         guessesContainer.appendChild(guessRow);
     }
+}
+
+function updateGuessUsageDisplay() {
+    if (!guessHeaderCountEl) return;
+    const usedGuesses = Math.min(Math.max(currentGuess, 0), maxGuesses);
+    guessHeaderCountEl.textContent = `${usedGuesses} out of ${maxGuesses}`;
 }
 
 function formatGuessPercentage(value) {
@@ -2110,9 +2134,10 @@ function addGuessToDisplay(guess) {
     const guessRows = guessesContainer.querySelectorAll('.guess-row');
     const currentRow = guessRows[currentGuess - 1];
     const guessField = currentRow.querySelector('.guess-field');
-    
+
     guessField.textContent = formatNumber(guess);
     guessField.classList.remove('empty');
+    updateGuessUsageDisplay();
 }
 
 // Show feedback for a guess
@@ -3097,7 +3122,7 @@ function clearCurrentGameState() {
 // Restore guesses display from saved state
 function restoreGuessesDisplay(savedGuesses) {
     const guessRows = guessesContainer.querySelectorAll('.guess-row');
-    
+
     savedGuesses.forEach((guess, index) => {
         if (index < guessRows.length) {
             const row = guessRows[index];
@@ -3173,6 +3198,7 @@ function restoreGuessesDisplay(savedGuesses) {
         }
     });
 
+    updateGuessUsageDisplay();
     applyGuessPlaceholderTexts();
 }
 

--- a/script.js
+++ b/script.js
@@ -175,8 +175,10 @@ async function fetchGuessDistribution(questionDate) {
         }
 
         const totalWins = Number(data[0]?.total_wins) || 0;
+        const totalCompleted = Number(data[0]?.total_completed) || 0;
         const distribution = {
             totalWins,
+            totalCompleted,
             entries: {}
         };
 
@@ -189,7 +191,7 @@ async function fetchGuessDistribution(questionDate) {
             const normalizedPercentage = Number(rawPercentage);
             const safePercentage = Number.isFinite(normalizedPercentage)
                 ? normalizedPercentage
-                : (totalWins > 0 ? (winCount / totalWins) * 100 : 0);
+                : (totalCompleted > 0 ? (winCount / totalCompleted) * 100 : 0);
 
             distribution.entries[guessNumber] = {
                 count: winCount,
@@ -1902,7 +1904,7 @@ function getGuessPlaceholderText(guessNumber) {
     const baseText = getGuessText(guessNumber);
     const distribution = currentQuestionGuessDistribution;
 
-    if (!distribution || !distribution.entries || distribution.totalWins <= 0) {
+    if (!distribution || !distribution.entries || distribution.totalCompleted <= 0) {
         return baseText;
     }
 

--- a/script.js
+++ b/script.js
@@ -123,7 +123,7 @@ async function saveStatsToSupabase(statsData) {
 // Fetch average guesses for a question from Supabase using RPC
 async function fetchAverageGuesses(questionDate) {
     if (!supabase) return null;
-    
+
     try {
         // Call the RPC function for server-side aggregation
         const { data, error } = await supabase
@@ -154,6 +154,80 @@ async function fetchAverageGuesses(questionDate) {
     } catch (error) {
         console.error('Error with average guesses fetch:', error);
         return null;
+    }
+}
+
+// Fetch distribution of winning guesses per guess number for a question
+async function fetchGuessDistribution(questionDate) {
+    if (!supabase) return null;
+
+    try {
+        const { data, error } = await supabase
+            .rpc('guess_distribution_for_date', { q_date: questionDate });
+
+        if (error) {
+            console.error('Error fetching guess distribution:', error);
+            return null;
+        }
+
+        if (!Array.isArray(data) || data.length === 0) {
+            return null;
+        }
+
+        const totalWins = Number(data[0]?.total_wins) || 0;
+        const distribution = {
+            totalWins,
+            entries: {}
+        };
+
+        for (const row of data) {
+            const guessNumber = Number(row?.guess_number);
+            if (!Number.isInteger(guessNumber)) continue;
+
+            const winCount = Number(row?.win_count) || 0;
+            const rawPercentage = row?.percentage;
+            const normalizedPercentage = Number(rawPercentage);
+            const safePercentage = Number.isFinite(normalizedPercentage)
+                ? normalizedPercentage
+                : (totalWins > 0 ? (winCount / totalWins) * 100 : 0);
+
+            distribution.entries[guessNumber] = {
+                count: winCount,
+                percentage: Math.max(0, Math.min(100, safePercentage))
+            };
+        }
+
+        return distribution;
+    } catch (error) {
+        console.error('Error with guess distribution fetch:', error);
+        return null;
+    }
+}
+
+// Load guess distribution and update placeholders when data is available
+async function loadGuessDistribution(questionDate, options = {}) {
+    if (!questionDate) return;
+
+    const { force = false } = options;
+    const hasCached = Object.prototype.hasOwnProperty.call(guessDistributionCache, questionDate);
+
+    if (!force && hasCached) {
+        const cached = guessDistributionCache[questionDate];
+        if (currentQuestion && currentQuestion.date === questionDate) {
+            currentQuestionGuessDistribution = cached;
+            applyGuessPlaceholderTexts();
+        }
+        return;
+    }
+
+    if (!supabase) return;
+
+    const distribution = await fetchGuessDistribution(questionDate);
+    guessDistributionCache[questionDate] = distribution;
+
+    if (currentQuestion && currentQuestion.date === questionDate) {
+        currentQuestionGuessDistribution = distribution;
+        applyGuessPlaceholderTexts();
     }
 }
 
@@ -405,7 +479,7 @@ function subscribeToComments(questionDate) {
             filter: `question_date=eq.${questionDate}`
         }, async () => {
             await updateCommentCount();
-            if (commentsSection && commentsSection.classList.contains('open')) {
+            if (currentView === 'comments') {
                 await loadComments();
             }
         })
@@ -413,16 +487,16 @@ function subscribeToComments(questionDate) {
 }
 
 function openComments() {
-    if (!commentsSection) return;
-    loadComments();
-    commentsSection.classList.add('open');
-    document.body.classList.add('no-scroll');
+    if (!commentsSection || !currentQuestion) return;
+    if (!ensureExtrasAccessible(currentQuestion.date)) {
+        return;
+    }
+    void loadComments();
+    navigateToView('comments', { date: currentQuestion.date });
 }
 
 function closeComments() {
-    if (!commentsSection) return;
-    commentsSection.classList.remove('open');
-    document.body.classList.remove('no-scroll');
+    goBack('game');
 }
 
 // Update the average tries display in the inline meta row
@@ -439,7 +513,9 @@ let completedQuestions = {}; // Changed from array to object to track win/loss s
 // URL Routing state
 let isNavigating = false;
 let currentView = 'welcome';
+let viewHistory = [];
 let todaysQuestion = null;
+let gameBackFallback = 'welcome';
 
 // Statistics
 let stats = {
@@ -460,6 +536,9 @@ let stats = {
 };
 
 let calibrationEnabled = true;
+
+const guessDistributionCache = Object.create(null);
+let currentQuestionGuessDistribution = null;
 
 // Database of Fermi questions with dates
 const fermiQuestions = [
@@ -975,6 +1054,78 @@ const fermiQuestions = [
         hint: "25.9M US households reported an income between $100,000 and $200,000 in 2022.",
         date: "2025-09-18",
         image: "data:image/svg+xml;charset=UTF-8,%3csvg xmlns='http://www.w3.org/2000/svg' width='100' height='100' viewBox='0 0 100 100'%3e%3crect width='100' height='100' fill='%23f8fafc'/%3e%3ctext x='50' y='62' font-size='40' text-anchor='middle' fill='%23374151'%3e️🇺🇸%3c/text%3e%3c/svg%3e"
+    },
+    {
+        question: "How many people work in McDonald's restaurants across the United States?",
+        answer: 800000,
+        category: "",
+        explanation: "",
+        hint: "There are 1,225 McDonald's restaurants in California.",
+        date: "2025-09-19",
+        image: "data:image/svg+xml;charset=UTF-8,%3csvg xmlns='http://www.w3.org/2000/svg' width='100' height='100' viewBox='0 0 100 100'%3e%3crect width='100' height='100' fill='%23f8fafc'/%3e%3ctext x='50' y='62' font-size='40' text-anchor='middle' fill='%23374151'%3e️🍔%3c/text%3e%3c/svg%3e"
+    },
+    {
+        question: "How many daily active users did Duolingo have as of March 2025?",
+        answer: 46600000,
+        category: "",
+        explanation: "",
+        hint: "Duolingo's revenue in the first three months of 2025 was $230.7 million.",
+        date: "2025-09-20",
+        image: "data:image/svg+xml;charset=UTF-8,%3csvg xmlns='http://www.w3.org/2000/svg' width='100' height='100' viewBox='0 0 100 100'%3e%3crect width='100' height='100' fill='%23f8fafc'/%3e%3ctext x='50' y='62' font-size='40' text-anchor='middle' fill='%23374151'%3e️📱%3c/text%3e%3c/svg%3e"
+    },
+    {
+        question: "How many commercial airline pilots are employed worldwide?",
+        answer: 382000,
+        category: "",
+        explanation: "",
+        hint: "There were around 36.4 million scheduled commercial airline flights in 2024.",
+        date: "2025-09-21",
+        image: "data:image/svg+xml;charset=UTF-8,%3csvg xmlns='http://www.w3.org/2000/svg' width='100' height='100' viewBox='0 0 100 100'%3e%3crect width='100' height='100' fill='%23f8fafc'/%3e%3ctext x='50' y='62' font-size='40' text-anchor='middle' fill='%23374151'%3e️🧑‍✈️%3c/text%3e%3c/svg%3e"
+    },
+    {
+        question: "How many divorces took place in Germany in 2024?",
+        answer: 129337,
+        category: "",
+        explanation: "",
+        hint: "Roughly 81% of the marriages formed in 2005 were still intact in 2015.",
+        date: "2025-09-22",
+        image: "data:image/svg+xml;charset=UTF-8,%3csvg xmlns='http://www.w3.org/2000/svg' width='100' height='100' viewBox='0 0 100 100'%3e%3crect width='100' height='100' fill='%23f8fafc'/%3e%3ctext x='50' y='62' font-size='40' text-anchor='middle' fill='%23374151'%3e️💔%3c/text%3e%3c/svg%3e"
+    },
+    {
+        question: "How many hours did the average journey from London to San Francisco take in 1900?",
+        answer: 293,
+        category: "",
+        explanation: "",
+        hint: "The straight-line distance between San Francisco and London is 5,354 miles (8,617 km).",
+        date: "2025-09-23",
+        image: "data:image/svg+xml;charset=UTF-8,%3csvg xmlns='http://www.w3.org/2000/svg' width='100' height='100' viewBox='0 0 100 100'%3e%3crect width='100' height='100' fill='%23f8fafc'/%3e%3ctext x='50' y='62' font-size='40' text-anchor='middle' fill='%23374151'%3e️🗽%3c/text%3e%3c/svg%3e"
+    },
+    {
+        question: "How many babies were born in the United States on New Year's Day in 2000?",
+        answer: 9083,
+        category: "",
+        explanation: "",
+        hint: "January 1st, 2000 was a Saturday, which typically has 27% fewer births than weekdays.",
+        date: "2025-09-24",
+        image: "data:image/svg+xml;charset=UTF-8,%3csvg xmlns='http://www.w3.org/2000/svg' width='100' height='100' viewBox='0 0 100 100'%3e%3crect width='100' height='100' fill='%23f8fafc'/%3e%3ctext x='50' y='62' font-size='40' text-anchor='middle' fill='%23374151'%3e️👶%3c/text%3e%3c/svg%3e"
+    },
+    {
+        question: "How many transactions did Visa process per day in 2024?",
+        answer: 639000000,
+        category: "",
+        explanation: "",
+        hint: "Roughly 57% of all credit and debit cards outside China carry the Visa brand.",
+        date: "2025-09-25",
+        image: "data:image/svg+xml;charset=UTF-8,%3csvg xmlns='http://www.w3.org/2000/svg' width='100' height='100' viewBox='0 0 100 100'%3e%3crect width='100' height='100' fill='%23f8fafc'/%3e%3ctext x='50' y='62' font-size='40' text-anchor='middle' fill='%23374151'%3e️💳%3c/text%3e%3c/svg%3e"
+    },
+    {
+        question: "How many radiologists are there in the United States?",
+        answer: 31960,
+        category: "",
+        explanation: "",
+        hint: "In 2023, around 35.7 million MRI scans were performed in the US.",
+        date: "2025-09-26",
+        image: "data:image/svg+xml;charset=UTF-8,%3csvg xmlns='http://www.w3.org/2000/svg' width='100' height='100' viewBox='0 0 100 100'%3e%3crect width='100' height='100' fill='%23f8fafc'/%3e%3ctext x='50' y='62' font-size='40' text-anchor='middle' fill='%23374151'%3e️🩻%3c/text%3e%3c/svg%3e"
     }
 ];
 
@@ -982,15 +1133,19 @@ const fermiQuestions = [
 const welcomeScreen = document.getElementById('welcome-screen');
 const gameView = document.getElementById('game-view');
 const calendarView = document.getElementById('calendar-view');
+const gameBackBtn = document.getElementById('game-back-btn');
+if (gameBackBtn) {
+    setGameBackDestination(gameBackFallback);
+}
 const playDailyBtn = document.getElementById('play-daily-btn');
 const calendarLinkBtn = document.getElementById('calendar-link-btn');
+const learnMoreBtn = document.getElementById('learn-more-btn');
 const homeBtn = document.getElementById('home-btn');
 const calendarBtn = document.getElementById('calendar-btn');
+const dailyChallengeCard = document.getElementById('daily-challenge-card');
 const dailyChallengeQuestionEl = document.getElementById('daily-challenge-question');
 const dailyChallengeDateEl = document.getElementById('daily-challenge-date');
 const dailyChallengeStatusEl = document.getElementById('daily-challenge-status');
-const dailyChallengeImageContainer = document.getElementById('daily-challenge-image-container');
-const dailyChallengeImageEl = document.getElementById('daily-challenge-image');
 const calendarMonthsContainer = document.getElementById('calendar-months');
 const questionText = document.getElementById('question-text');
 const questionCategory = document.getElementById('question-category');
@@ -1002,9 +1157,8 @@ const hintText = document.getElementById('hint-text');
 const hintBody = document.getElementById('hint-body');
 const questionMeta = document.getElementById('question-meta');
 const sourceBtn = document.getElementById('source-btn');
-const sourceModal = document.getElementById('source-modal');
+const sourceView = document.getElementById('source-view');
 const sourceText = document.getElementById('source-text');
-const closeSourceBtn = document.getElementById('close-source-btn');
 const gameResult = document.getElementById('game-result');
 const resultMessage = document.getElementById('result-message');
 const resultEmoji = document.getElementById('result-emoji');
@@ -1039,15 +1193,13 @@ const modalAnswer = document.getElementById('modal-answer');
 const newGameBtn = document.getElementById('new-game-btn');
 const helpBtn = document.getElementById('help-btn');
 const statsBtn = document.getElementById('stats-btn');
-const helpModal = document.getElementById('help-modal');
-const statsModal = document.getElementById('stats-modal');
+const helpView = document.getElementById('help-view');
+const statsView = document.getElementById('stats-view');
 const questionsModal = document.getElementById('questions-modal');
 const strategyTipsBtn = document.getElementById('strategy-tips-btn');
 // Hint elements
 const hintModalBtn = document.getElementById('hint-modal-btn');
 const questionsList = document.getElementById('questions-list');
-const closeHelpBtn = document.getElementById('close-help-btn');
-const closeStatsBtn = document.getElementById('close-stats-btn');
 const closeQuestionsBtn = document.getElementById('close-questions-btn');
 const shareBtn = document.getElementById('share-btn');
 const shareStatsBtn = document.getElementById('share-stats-btn');
@@ -1065,6 +1217,22 @@ const commentsList = document.getElementById('comments-list');
 const commentInput = document.getElementById('comment-input');
 const commentSubmitBtn = document.getElementById('comment-submit-btn');
 const commentCountEl = document.getElementById('comment-count');
+const helpBackBtn = document.getElementById('help-back-btn');
+const statsBackBtn = document.getElementById('stats-back-btn');
+const sourceBackBtn = document.getElementById('source-back-btn');
+const calendarBackBtn = document.getElementById('calendar-back-btn');
+
+const viewElements = {
+    welcome: welcomeScreen,
+    game: gameView,
+    calendar: calendarView,
+    help: helpView,
+    stats: statsView,
+    source: sourceView,
+    comments: commentsSection
+};
+
+const urlSyncedViews = new Set(['welcome', 'calendar', 'help', 'stats', 'source', 'comments']);
 
 
 // Confidence tooltip
@@ -1099,7 +1267,7 @@ function initGame() {
     let navigatedFromRoute = false;
 
     if (initialRoute.view === 'game' && initialRoute.date) {
-        navigatedFromRoute = navigateToQuestion(initialRoute.date);
+        navigatedFromRoute = navigateToQuestion(initialRoute.date, { skipHistory: true });
     }
 
     if (!navigatedFromRoute) {
@@ -1114,15 +1282,59 @@ function initGame() {
 
     if (navigatedFromRoute) {
         setActiveView('game', { skipURLUpdate: true, force: true });
-    } else if (initialRoute.view === 'calendar') {
-        setActiveView('calendar', { skipURLUpdate: true, force: true });
-    } else if (initialRoute.view === 'game' && initialRoute.date) {
-        setActiveView('game', { skipURLUpdate: true, force: true });
-        if (currentQuestion) {
-            updateURL(currentQuestion.date);
-        }
     } else {
-        setActiveView('welcome', { force: true });
+        switch (initialRoute.view) {
+            case 'calendar':
+                setActiveView('calendar', { skipURLUpdate: true, force: true });
+                break;
+            case 'game':
+                if (initialRoute.date && currentQuestion) {
+                    setActiveView('game', { skipURLUpdate: true, force: true });
+                    updateURL(currentQuestion.date);
+                } else {
+                    navigateToCurrentQuestion();
+                }
+                break;
+            case 'help':
+                setActiveView('help', { skipURLUpdate: true, force: true });
+                break;
+            case 'stats':
+                updateStatsDisplay();
+                setActiveView('stats', { skipURLUpdate: true, force: true });
+                break;
+            case 'source': {
+                const targetDate = initialRoute.date || (currentQuestion ? currentQuestion.date : null);
+                if (!ensureExtrasAccessible(targetDate, { skipHistory: true })) {
+                    break;
+                }
+                const resolvedDate = targetDate || (currentQuestion ? currentQuestion.date : null);
+                if (!ensureQuestionSelected(resolvedDate)) {
+                    navigateToCurrentQuestion();
+                    break;
+                }
+                prepareSourceView();
+                setActiveView('source', { skipURLUpdate: true, force: true, date: resolvedDate });
+                break;
+            }
+            case 'comments': {
+                const targetDate = initialRoute.date || (currentQuestion ? currentQuestion.date : null);
+                if (!ensureExtrasAccessible(targetDate, { skipHistory: true })) {
+                    break;
+                }
+                const resolvedDate = targetDate || (currentQuestion ? currentQuestion.date : null);
+                if (!ensureQuestionSelected(resolvedDate)) {
+                    navigateToCurrentQuestion();
+                    break;
+                }
+                void loadComments();
+                setActiveView('comments', { skipURLUpdate: true, force: true, date: resolvedDate });
+                break;
+            }
+            case 'welcome':
+            default:
+                setActiveView('welcome', { force: true });
+                break;
+        }
     }
 
     setupEventListeners();
@@ -1170,7 +1382,9 @@ function startNewGame(skipURLUpdate = false) {
         console.error('No questions available');
         return;
     }
-    
+
+    updateGameBackFallback(currentQuestion, currentView);
+
     // Check if this question already has saved progress
     const storageKey = `fermiGameState_${currentQuestion.date}`;
     const existingSavedState = localStorage.getItem(storageKey);
@@ -1185,11 +1399,13 @@ function startNewGame(skipURLUpdate = false) {
     currentGuess = 0;
     gameWon = false;
     gameOver = false;
-    
+
     // Update display
     updateQuestionDisplay(currentQuestion);
+    currentQuestionGuessDistribution = guessDistributionCache[currentQuestion.date] || null;
     clearGuesses();
-    
+    void loadGuessDistribution(currentQuestion.date);
+
     // Update page title
     updatePageTitle(currentQuestion);
     
@@ -1238,6 +1454,25 @@ function getCurrentDate() {
     return `${year}-${month}-${day}`;
 }
 
+function setGameBackDestination(destination) {
+    const target = destination === 'calendar' ? 'calendar' : 'welcome';
+    gameBackFallback = target;
+    if (gameBackBtn) {
+        gameBackBtn.textContent = target === 'calendar' ? 'Back to calendar' : 'Back';
+    }
+}
+
+function updateGameBackFallback(_question, sourceView = currentView) {
+    if (sourceView === 'calendar') {
+        setGameBackDestination('calendar');
+        return;
+    }
+
+    if (sourceView !== 'game') {
+        setGameBackDestination('welcome');
+    }
+}
+
 // Get question for a specific date
 function getQuestionForDate(date) {
     return fermiQuestions.find(q => q.date === date);
@@ -1248,6 +1483,14 @@ function formatDateForDisplay(dateString) {
     const date = new Date(dateString);
     const options = { day: 'numeric', month: 'long', year: 'numeric' };
     return date.toLocaleDateString('en-GB', options);
+}
+
+function formatDateForBadge(dateString) {
+    const date = new Date(dateString);
+    if (Number.isNaN(date.getTime())) {
+        return '';
+    }
+    return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
 }
 
 // Get question based on current date and game state
@@ -1292,15 +1535,22 @@ function refreshDailyChallengeSummary() {
     const todayQuestion = getTodaysQuestion();
     todaysQuestion = todayQuestion || null;
 
+    if (dailyChallengeCard) {
+        dailyChallengeCard.classList.remove(
+            'daily-challenge-card--ready',
+            'daily-challenge-card--won',
+            'daily-challenge-card--lost'
+        );
+    }
+
     if (!todayQuestion) {
         dailyChallengeQuestionEl.textContent = 'No daily challenge is available right now.';
         dailyChallengeDateEl.textContent = '';
+        dailyChallengeDateEl.removeAttribute('title');
+        dailyChallengeDateEl.removeAttribute('aria-label');
         if (dailyChallengeStatusEl) {
             dailyChallengeStatusEl.textContent = '';
             dailyChallengeStatusEl.classList.remove('status-won', 'status-lost');
-        }
-        if (dailyChallengeImageContainer) {
-            dailyChallengeImageContainer.style.display = 'none';
         }
         if (playDailyBtn) {
             playDailyBtn.disabled = true;
@@ -1309,25 +1559,19 @@ function refreshDailyChallengeSummary() {
         return;
     }
 
-    const todayDate = getCurrentDate();
-    const formattedDate = todayQuestion.date === todayDate
-        ? 'Today'
-        : formatDateForDisplay(todayQuestion.date);
+    const badgeDate = formatDateForBadge(todayQuestion.date);
+    const fullDateLabel = formatDateForDisplay(todayQuestion.date);
 
-    dailyChallengeDateEl.textContent = formattedDate;
-    dailyChallengeQuestionEl.textContent = todayQuestion.question;
-
-    if (dailyChallengeImageContainer) {
-        if (todayQuestion.image) {
-            dailyChallengeImageContainer.style.display = 'flex';
-            if (dailyChallengeImageEl) {
-                dailyChallengeImageEl.src = todayQuestion.image;
-                dailyChallengeImageEl.alt = `Image for ${todayQuestion.question}`;
-            }
-        } else {
-            dailyChallengeImageContainer.style.display = 'none';
-        }
+    dailyChallengeDateEl.textContent = badgeDate;
+    if (fullDateLabel) {
+        dailyChallengeDateEl.title = fullDateLabel;
+        dailyChallengeDateEl.setAttribute('aria-label', `Question date: ${fullDateLabel}`);
+    } else {
+        dailyChallengeDateEl.removeAttribute('title');
+        dailyChallengeDateEl.removeAttribute('aria-label');
     }
+
+    dailyChallengeQuestionEl.textContent = todayQuestion.question;
 
     if (playDailyBtn) {
         playDailyBtn.disabled = false;
@@ -1346,12 +1590,20 @@ function refreshDailyChallengeSummary() {
         if (playDailyBtn) {
             playDailyBtn.textContent = 'Review';
         }
+        if (dailyChallengeCard) {
+            dailyChallengeCard.classList.add(
+                completed.won ? 'daily-challenge-card--won' : 'daily-challenge-card--lost'
+            );
+        }
     } else {
         if (dailyChallengeStatusEl) {
             dailyChallengeStatusEl.textContent = 'Ready to play';
         }
         if (playDailyBtn) {
             playDailyBtn.textContent = 'Play';
+        }
+        if (dailyChallengeCard) {
+            dailyChallengeCard.classList.add('daily-challenge-card--ready');
         }
     }
 }
@@ -1362,34 +1614,52 @@ function updateHash(newHash) {
     }
 }
 
+function getHashForView(view, date) {
+    switch (view) {
+        case 'welcome':
+            return '#/welcome';
+        case 'calendar':
+            return '#/calendar';
+        case 'help':
+            return '#/help';
+        case 'stats':
+            return '#/stats';
+        case 'source':
+            return date ? `#/${date}/source` : '#/source';
+        case 'comments':
+            return date ? `#/${date}/comments` : '#/comments';
+        default:
+            return null;
+    }
+}
+
 function setActiveView(view, options = {}) {
-    const { skipURLUpdate = false, force = false } = options;
+    const { skipURLUpdate = false, force = false, date } = options;
     if (!force && currentView === view) {
         if (view === 'calendar') {
             renderCalendar();
         } else if (view === 'welcome') {
             refreshDailyChallengeSummary();
+        } else if (view === 'game') {
+            if (guessInput && !('ontouchstart' in window) && !navigator.maxTouchPoints) {
+                setTimeout(() => guessInput.focus(), 150);
+            }
         }
         return;
     }
 
     currentView = view;
 
-    if (welcomeScreen) {
-        welcomeScreen.classList.toggle('active', view === 'welcome');
-    }
-    if (gameView) {
-        gameView.classList.toggle('active', view === 'game');
-    }
-    if (calendarView) {
-        calendarView.classList.toggle('active', view === 'calendar');
-    }
+    Object.entries(viewElements).forEach(([key, element]) => {
+        if (!element) return;
+        element.classList.toggle('active', key === view);
+    });
 
     if (!skipURLUpdate) {
-        if (view === 'welcome') {
-            updateHash('#/welcome');
-        } else if (view === 'calendar') {
-            updateHash('#/calendar');
+        const viewDate = date || (currentQuestion ? currentQuestion.date : null);
+        const newHash = getHashForView(view, viewDate);
+        if (newHash) {
+            updateHash(newHash);
         }
     }
 
@@ -1400,6 +1670,53 @@ function setActiveView(view, options = {}) {
     } else if (view === 'game') {
         if (guessInput && !('ontouchstart' in window) && !navigator.maxTouchPoints) {
             setTimeout(() => guessInput.focus(), 150);
+        }
+    }
+}
+
+function navigateToView(view, options = {}) {
+    const { skipHistory = false, skipURLUpdate, force = false, date } = options;
+
+    if (view === 'source' || view === 'comments') {
+        const targetDate = date || (currentQuestion ? currentQuestion.date : null);
+        if (!ensureExtrasAccessible(targetDate, { skipHistory })) {
+            return;
+        }
+    }
+
+    if (!skipHistory && currentView !== view) {
+        viewHistory.push(currentView);
+    }
+    const shouldSkipURL = skipURLUpdate !== undefined
+        ? skipURLUpdate
+        : !urlSyncedViews.has(view);
+    setActiveView(view, { skipURLUpdate: shouldSkipURL, force, date });
+}
+
+function goBack(fallbackView = 'welcome') {
+    if (viewHistory.length > 0) {
+        const previous = viewHistory.pop();
+        const skipURLUpdate = !urlSyncedViews.has(previous);
+        const options = { skipURLUpdate, force: true };
+        if ((previous === 'source' || previous === 'comments') && currentQuestion) {
+            options.date = currentQuestion.date;
+        }
+        setActiveView(previous, options);
+        if (previous === 'game' && currentQuestion) {
+            updateURL(currentQuestion.date);
+        }
+        return;
+    }
+
+    if (fallbackView) {
+        const skipURLUpdate = !urlSyncedViews.has(fallbackView);
+        const options = { skipURLUpdate, force: true };
+        if ((fallbackView === 'source' || fallbackView === 'comments') && currentQuestion) {
+            options.date = currentQuestion.date;
+        }
+        setActiveView(fallbackView, options);
+        if (fallbackView === 'game' && currentQuestion) {
+            updateURL(currentQuestion.date);
         }
     }
 }
@@ -1428,7 +1745,10 @@ function renderCalendar() {
     calendarMonthsContainer.innerHTML = '';
     const dayLabels = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
 
-    questionsByMonth.forEach((monthQuestions, monthKey) => {
+    const monthEntries = Array.from(questionsByMonth.entries()).sort((a, b) => b[0].localeCompare(a[0]));
+
+    monthEntries.forEach(([monthKey, monthQuestions]) => {
+        const sortedMonthQuestions = [...monthQuestions].sort((a, b) => a.date.localeCompare(b.date));
         const monthContainer = document.createElement('div');
         monthContainer.className = 'calendar-month';
 
@@ -1448,7 +1768,7 @@ function renderCalendar() {
         });
 
         const questionByDay = new Map();
-        monthQuestions.forEach((question) => {
+        sortedMonthQuestions.forEach((question) => {
             const dayNumber = parseInt(question.date.slice(8, 10), 10);
             questionByDay.set(dayNumber, question);
         });
@@ -1542,27 +1862,65 @@ function renderCalendar() {
 // Clear previous guesses
 function clearGuesses() {
     guessesContainer.innerHTML = '';
-    
+
     // Create empty guess rows
     for (let i = 0; i < maxGuesses; i++) {
         const guessRow = document.createElement('div');
         guessRow.className = 'guess-row';
-        
+
         const guessField = document.createElement('div');
         guessField.className = 'guess-field empty';
-        
+
         // Set the appropriate text for each guess position
         const guessNumber = i + 1;
-        const guessText = getGuessText(guessNumber);
+        const guessText = getGuessPlaceholderText(guessNumber);
         guessField.textContent = guessText;
-        
+
         const feedbackButton = document.createElement('button');
         feedbackButton.className = 'feedback-button hidden';
-        
+
         guessRow.appendChild(guessField);
         guessRow.appendChild(feedbackButton);
         guessesContainer.appendChild(guessRow);
     }
+}
+
+function formatGuessPercentage(value) {
+    if (!Number.isFinite(value) || value <= 0) {
+        return '0';
+    }
+
+    if (value >= 10) {
+        return String(Math.round(value));
+    }
+
+    const rounded = Number(value.toFixed(1));
+    return String(rounded).replace(/\.0$/, '');
+}
+
+function getGuessPlaceholderText(guessNumber) {
+    const baseText = getGuessText(guessNumber);
+    const distribution = currentQuestionGuessDistribution;
+
+    if (!distribution || !distribution.entries || distribution.totalWins <= 0) {
+        return baseText;
+    }
+
+    const entry = distribution.entries[guessNumber];
+    const percentage = entry && Number.isFinite(entry.percentage) ? entry.percentage : 0;
+    const formatted = formatGuessPercentage(percentage);
+    return `${baseText} · ${formatted}% of players`;
+}
+
+function applyGuessPlaceholderTexts() {
+    if (!guessesContainer) return;
+    const guessRows = guessesContainer.querySelectorAll('.guess-row');
+    guessRows.forEach((row, index) => {
+        const guessField = row.querySelector('.guess-field');
+        if (!guessField || !guessField.classList.contains('empty')) return;
+        const guessNumber = index + 1;
+        guessField.textContent = getGuessPlaceholderText(guessNumber);
+    });
 }
 
 // Helper function to get the text for each guess position
@@ -2001,8 +2359,15 @@ function endGame() {
                 guesses: savedGuesses,
                 completed_at: new Date().toISOString()
             };
-            
+
             saveGameToSupabase(gameData);
+
+            const questionDate = currentQuestion.date;
+            if (questionDate) {
+                setTimeout(() => {
+                    void loadGuessDistribution(questionDate, { force: true });
+                }, 800);
+            }
         }
     }
     
@@ -2074,15 +2439,71 @@ function startNewGameFromModal() {
     startNewGame();
 }
 
-// Show help modal
-function showHelp() {
-    helpModal.style.display = 'block';
+function prepareSourceView() {
+    if (!sourceView || !currentQuestion || !sourceText) return;
+
+    const explanation = currentQuestion.explanation || 'No source available for this question as of now. This is a new feature that will be available in the coming days.';
+    sourceText.textContent = '';
+    const asHtml = /<a\s|https?:\/\//i.test(explanation);
+    if (asHtml) {
+        sourceText.innerHTML = explanation;
+    } else {
+        sourceText.textContent = explanation;
+    }
+
+    if (medianFirstGuessText) medianFirstGuessText.textContent = '';
+    const playersEl = document.getElementById('source-players-count');
+    const winRateEl = document.getElementById('source-win-rate');
+    const avgTriesEl = document.getElementById('source-avg-tries');
+    if (playersEl) playersEl.textContent = '0';
+    if (winRateEl) winRateEl.textContent = '0%';
+    if (avgTriesEl) avgTriesEl.textContent = '0';
+
+    fetchMedianFirstGuess(currentQuestion.date)
+        .then(median => {
+            if (median != null && medianFirstGuessText) {
+                medianFirstGuessText.textContent = `The median first guess was ${formatNumber(median)}`;
+            }
+        })
+        .catch(() => {/* ignore */});
+
+    if (firstGuessPercentileText) firstGuessPercentileText.textContent = '';
+    fetchFirstGuessPercentile(currentQuestion.date)
+        .then(percentile => {
+            if (typeof percentile === 'number' && firstGuessPercentileText) {
+                firstGuessPercentileText.textContent = `Your first guess is in the ${percentile}th percentile, meaning you've performed as well or better than ${percentile}% of players.`;
+            }
+        })
+        .catch(() => {/* ignore */});
+
+    fetchAverageGuesses(currentQuestion.date)
+        .then(avgData => {
+            if (!avgData) return;
+            if (playersEl && typeof avgData.totalPlayers === 'number') {
+                playersEl.textContent = `${avgData.totalPlayers}`;
+            }
+            if (winRateEl && typeof avgData.winRate === 'number') {
+                winRateEl.textContent = `${avgData.winRate}%`;
+            }
+            if (avgTriesEl && typeof avgData.average === 'number') {
+                const value = avgData.average;
+                avgTriesEl.textContent = Number.isInteger(value) ? `${value}` : value.toFixed(1);
+            }
+        })
+        .catch(() => {/* ignore */});
 }
 
-// Show stats modal
+// Show help view
+function showHelp() {
+    if (!helpView) return;
+    navigateToView('help');
+}
+
+// Show stats view
 function showStats() {
     updateStatsDisplay();
-    statsModal.style.display = 'block';
+    if (!statsView) return;
+    navigateToView('stats');
 }
 
 // Update stats display
@@ -2572,6 +2993,7 @@ function loadCurrentGameState() {
             
             // Restore game state
             currentQuestion = gameState.question;
+            updateGameBackFallback(currentQuestion, currentView);
             currentGuess = gameState.currentGuess;
             gameWon = gameState.gameWon;
             gameOver = gameState.gameOver;
@@ -2582,10 +3004,12 @@ function loadCurrentGameState() {
             
             // Update URL to reflect the restored question
             updateURL(currentQuestion.date);
-            
+
             // Clear guesses container and restore saved guesses
+            currentQuestionGuessDistribution = guessDistributionCache[currentQuestion.date] || null;
             clearGuesses();
             restoreGuessesDisplay(gameState.guesses);
+            void loadGuessDistribution(currentQuestion.date);
 
             // Update game state display
             if (gameOver) {
@@ -2715,6 +3139,8 @@ function restoreGuessesDisplay(savedGuesses) {
             }
         }
     });
+
+    applyGuessPlaceholderTexts();
 }
 
 // Update display elements for ended game (without updating stats)
@@ -2870,6 +3296,8 @@ function updatePageTitle(question) {
 
 // Select a specific question
 function selectQuestion(question) {
+    updateGameBackFallback(question, currentView);
+
     // Save current game state before switching (if there's an active game)
     if (currentQuestion && currentGuess > 0 && !gameOver && !completedQuestions[currentQuestion.date]) {
         saveCurrentGameState();
@@ -2877,7 +3305,8 @@ function selectQuestion(question) {
     
     currentQuestion = question;
     updateQuestionDisplay(currentQuestion);
-    
+    currentQuestionGuessDistribution = guessDistributionCache[question.date] || null;
+
     // Update page title
     updatePageTitle(currentQuestion);
     
@@ -2977,6 +3406,9 @@ function selectQuestion(question) {
     if (!isNavigating && currentView === 'game') {
         updateURL(question.date);
     }
+
+    applyGuessPlaceholderTexts();
+    void loadGuessDistribution(question.date);
 
     refreshDailyChallengeSummary();
     renderCalendar();
@@ -3112,7 +3544,7 @@ function showShareFeedback(message) {
         color: white;
         padding: 12px 20px;
         border-radius: 8px;
-        font-family: 'Press Start 2P', monospace;
+        font-family: 'Nunito', sans-serif;
         font-size: 0.7rem;
         z-index: 10000;
     `;
@@ -3157,6 +3589,27 @@ function parseURL() {
         return { view: 'calendar' };
     }
 
+    if (hash === '#/help') {
+        return { view: 'help' };
+    }
+
+    if (hash === '#/stats') {
+        return { view: 'stats' };
+    }
+
+    const datedViewMatch = hash.match(/^#\/(\d{4}-\d{2}-\d{2})\/(comments|source)$/);
+    if (datedViewMatch) {
+        return { view: datedViewMatch[2], date: datedViewMatch[1] };
+    }
+
+    if (hash === '#/source') {
+        return { view: 'source' };
+    }
+
+    if (hash === '#/comments') {
+        return { view: 'comments' };
+    }
+
     const questionMatch = hash.match(/^#\/(\d{4}-\d{2}-\d{2})$/);
     if (questionMatch) {
         return { view: 'game', date: questionMatch[1] };
@@ -3169,8 +3622,73 @@ function parseURL() {
     return { view: 'welcome' };
 }
 
+function ensureQuestionSelected(questionDate) {
+    if (questionDate) {
+        if (currentQuestion && currentQuestion.date === questionDate) {
+            return true;
+        }
+        const question = getQuestionForDate(questionDate);
+        if (!question) {
+            return false;
+        }
+        const today = getCurrentDate();
+        if (question.date > today) {
+            return false;
+        }
+        isNavigating = true;
+        selectQuestion(question);
+        isNavigating = false;
+        return true;
+    }
+
+    if (currentQuestion) {
+        return true;
+    }
+
+    const defaultQuestion = getCurrentQuestion();
+    if (!defaultQuestion) {
+        return false;
+    }
+
+    isNavigating = true;
+    selectQuestion(defaultQuestion);
+    isNavigating = false;
+    return true;
+}
+
+function hasCompletedQuestion(questionDate) {
+    if (!questionDate) return false;
+    return Boolean(completedQuestions && completedQuestions[questionDate]);
+}
+
+function ensureExtrasAccessible(questionDate, options = {}) {
+    const { skipHistory = false } = options;
+
+    if (!questionDate) {
+        navigateToCurrentQuestion();
+        return false;
+    }
+
+    if (!hasCompletedQuestion(questionDate)) {
+        navigateToQuestion(questionDate, { skipHistory });
+        return false;
+    }
+
+    return true;
+}
+
 // Navigate to a specific question by date
-function navigateToQuestion(questionDate) {
+function navigateToQuestion(questionDate, options = {}) {
+    const { skipHistory = false, sourceView } = options;
+    const previousView = sourceView !== undefined ? sourceView : currentView;
+
+    if (!skipHistory && previousView && previousView !== 'game') {
+        const lastEntry = viewHistory[viewHistory.length - 1];
+        if (lastEntry !== previousView) {
+            viewHistory.push(previousView);
+        }
+    }
+
     const question = getQuestionForDate(questionDate);
 
     if (question) {
@@ -3213,16 +3731,58 @@ function navigateToCurrentQuestion() {
 function handlePopState() {
     const route = parseURL();
 
-    if (route.view === 'calendar') {
-        setActiveView('calendar', { skipURLUpdate: true, force: true });
-        return;
-    }
-
-    if (route.view === 'game' && route.date) {
-        if (!navigateToQuestion(route.date)) {
-            navigateToCurrentQuestion();
+    switch (route.view) {
+        case 'calendar':
+            setActiveView('calendar', { skipURLUpdate: true, force: true });
+            return;
+        case 'help':
+            setActiveView('help', { skipURLUpdate: true, force: true });
+            return;
+        case 'stats':
+            updateStatsDisplay();
+            setActiveView('stats', { skipURLUpdate: true, force: true });
+            return;
+        case 'source': {
+            const targetDate = route.date || (currentQuestion ? currentQuestion.date : null);
+            if (!ensureExtrasAccessible(targetDate, { skipHistory: true })) {
+                return;
+            }
+            const resolvedDate = targetDate || (currentQuestion ? currentQuestion.date : null);
+            if (!ensureQuestionSelected(resolvedDate)) {
+                navigateToCurrentQuestion();
+                return;
+            }
+            prepareSourceView();
+            setActiveView('source', { skipURLUpdate: true, force: true, date: resolvedDate });
+            return;
         }
-        return;
+        case 'comments': {
+            const targetDate = route.date || (currentQuestion ? currentQuestion.date : null);
+            if (!ensureExtrasAccessible(targetDate, { skipHistory: true })) {
+                return;
+            }
+            const resolvedDate = targetDate || (currentQuestion ? currentQuestion.date : null);
+            if (!ensureQuestionSelected(resolvedDate)) {
+                navigateToCurrentQuestion();
+                return;
+            }
+            void loadComments();
+            setActiveView('comments', { skipURLUpdate: true, force: true, date: resolvedDate });
+            return;
+        }
+        case 'game':
+            if (route.date) {
+                if (!navigateToQuestion(route.date, { skipHistory: true })) {
+                    navigateToCurrentQuestion();
+                }
+                return;
+            }
+            break;
+        case 'welcome':
+            setActiveView('welcome', { skipURLUpdate: true, force: true });
+            return;
+        default:
+            break;
     }
 
     setActiveView('welcome', { skipURLUpdate: true, force: true });
@@ -3240,14 +3800,54 @@ function initRouting(skipInitialNavigation = false) {
 
     // Handle initial page load
     const route = parseURL();
-    if (route.view === 'calendar') {
-        setActiveView('calendar', { skipURLUpdate: true, force: true });
-    } else if (route.view === 'game' && route.date) {
-        if (!navigateToQuestion(route.date)) {
-            navigateToCurrentQuestion();
+    switch (route.view) {
+        case 'calendar':
+            setActiveView('calendar', { skipURLUpdate: true, force: true });
+            break;
+        case 'game':
+            if (!route.date || !navigateToQuestion(route.date, { skipHistory: true })) {
+                navigateToCurrentQuestion();
+            }
+            break;
+        case 'help':
+            setActiveView('help', { skipURLUpdate: true, force: true });
+            break;
+        case 'stats':
+            updateStatsDisplay();
+            setActiveView('stats', { skipURLUpdate: true, force: true });
+            break;
+        case 'source': {
+            const targetDate = route.date || (currentQuestion ? currentQuestion.date : null);
+            if (!ensureExtrasAccessible(targetDate, { skipHistory: true })) {
+                break;
+            }
+            const resolvedDate = targetDate || (currentQuestion ? currentQuestion.date : null);
+            if (!ensureQuestionSelected(resolvedDate)) {
+                navigateToCurrentQuestion();
+                break;
+            }
+            prepareSourceView();
+            setActiveView('source', { skipURLUpdate: true, force: true, date: resolvedDate });
+            break;
         }
-    } else {
-        setActiveView('welcome', { force: true });
+        case 'comments': {
+            const targetDate = route.date || (currentQuestion ? currentQuestion.date : null);
+            if (!ensureExtrasAccessible(targetDate, { skipHistory: true })) {
+                break;
+            }
+            const resolvedDate = targetDate || (currentQuestion ? currentQuestion.date : null);
+            if (!ensureQuestionSelected(resolvedDate)) {
+                navigateToCurrentQuestion();
+                break;
+            }
+            void loadComments();
+            setActiveView('comments', { skipURLUpdate: true, force: true, date: resolvedDate });
+            break;
+        }
+        case 'welcome':
+        default:
+            setActiveView('welcome', { force: true });
+            break;
     }
 }
 
@@ -3300,19 +3900,23 @@ function setupEventListeners() {
 
     if (calendarLinkBtn) {
         calendarLinkBtn.addEventListener('click', () => {
-            setActiveView('calendar');
+            navigateToView('calendar');
         });
+    }
+
+    if (learnMoreBtn) {
+        learnMoreBtn.addEventListener('click', showHelp);
     }
 
     if (homeBtn) {
         homeBtn.addEventListener('click', () => {
-            setActiveView('welcome');
+            navigateToView('welcome');
         });
     }
 
     if (calendarBtn) {
         calendarBtn.addEventListener('click', () => {
-            setActiveView('calendar');
+            navigateToView('calendar');
         });
     }
 
@@ -3419,65 +4023,17 @@ function setupEventListeners() {
         updateSelected(confidenceInput.value);
     }
     
-    // Source button opens explanation modal
-    if (sourceBtn && sourceModal) {
+    // Source button opens explanation view
+    if (sourceBtn && sourceView) {
         sourceBtn.addEventListener('click', () => {
-            if (currentQuestion && sourceText) {
-                const explanation = currentQuestion.explanation || 'No source available for this question as of now. This is a new feature that will be available in the coming days.';
-                // Allow simple links if present; otherwise treat as plain text
-                sourceText.textContent = '';
-                const asHtml = /<a\s|https?:\/\//i.test(explanation);
-                if (asHtml) {
-                    sourceText.innerHTML = explanation;
-                } else {
-                    sourceText.textContent = explanation;
-                }
-                // Reset stats placeholders before fetching
-                if (medianFirstGuessText) medianFirstGuessText.textContent = '';
-                const playersEl = document.getElementById('source-players-count');
-                const winRateEl = document.getElementById('source-win-rate');
-                const avgTriesEl = document.getElementById('source-avg-tries');
-                if (playersEl) playersEl.textContent = '0';
-                if (winRateEl) winRateEl.textContent = '0%';
-                if (avgTriesEl) avgTriesEl.textContent = '0';
-
-                // Fetch median first guess
-                fetchMedianFirstGuess(currentQuestion.date)
-                    .then(median => {
-                        if (median != null && medianFirstGuessText) {
-                            medianFirstGuessText.textContent = `The median first guess was ${formatNumber(median)}`;
-                        }
-                    })
-                    .catch(() => {/* ignore */});
-
-                // Fetch user's first-guess percentile
-                if (firstGuessPercentileText) firstGuessPercentileText.textContent = '';
-                fetchFirstGuessPercentile(currentQuestion.date)
-                    .then(p => {
-                        if (typeof p === 'number' && firstGuessPercentileText) {
-                            firstGuessPercentileText.textContent = `Your first guess is in the ${p}th percentile, meaning you've performed as well or better than ${p}% of players.`;
-                        }
-                    })
-                    .catch(() => {/* ignore */});
-
-                // Fetch aggregate stats (players, win rate)
-                fetchAverageGuesses(currentQuestion.date)
-                    .then(avgData => {
-                        if (!avgData) return;
-                        if (playersEl && typeof avgData.totalPlayers === 'number') {
-                            playersEl.textContent = `${avgData.totalPlayers}`;
-                        }
-                        if (winRateEl && typeof avgData.winRate === 'number') {
-                            winRateEl.textContent = `${avgData.winRate}%`;
-                        }
-                        if (avgTriesEl && typeof avgData.average === 'number') {
-                            const v = avgData.average;
-                            avgTriesEl.textContent = Number.isInteger(v) ? `${v}` : v.toFixed(1);
-                        }
-                    })
-                    .catch(() => {/* ignore */});
+            if (!currentQuestion) return;
+            const targetDate = currentQuestion.date;
+            if (!hasCompletedQuestion(targetDate)) {
+                navigateToQuestion(targetDate);
+                return;
             }
-            sourceModal.style.display = 'block';
+            prepareSourceView();
+            navigateToView('source', { date: targetDate });
         });
     }
 
@@ -3497,9 +4053,9 @@ function setupEventListeners() {
     });
     
     // Close buttons
-    closeHelpBtn.addEventListener('click', () => closeModal(helpModal));
-    closeStatsBtn.addEventListener('click', () => closeModal(statsModal));
-    closeQuestionsBtn.addEventListener('click', () => closeModal(questionsModal));
+    if (closeQuestionsBtn) {
+        closeQuestionsBtn.addEventListener('click', () => closeModal(questionsModal));
+    }
 
     // Comment buttons
     if (commentsBtn) commentsBtn.addEventListener('click', openComments);
@@ -3517,9 +4073,10 @@ function setupEventListeners() {
     // Share buttons
     shareBtn.addEventListener('click', shareGame);
     shareStatsBtn.addEventListener('click', shareStats);
-        
+
     // Close modals when clicking outside (desktop + mobile)
-    [helpModal, statsModal, questionsModal, sourceModal].forEach(modal => {
+    [questionsModal, gameOverModal].forEach(modal => {
+        if (!modal) return;
         ['click', 'touchend'].forEach(event => {
             modal.addEventListener(event, e => e.target === modal && closeModal(modal));
         });
@@ -3532,10 +4089,12 @@ function setupEventListeners() {
         });
     });
 
-    // Close source modal via button
-    if (closeSourceBtn && sourceModal) {
-        closeSourceBtn.addEventListener('click', () => closeModal(sourceModal));
-    }
+    // Back buttons for secondary views
+    if (gameBackBtn) gameBackBtn.addEventListener('click', () => goBack(gameBackFallback));
+    if (helpBackBtn) helpBackBtn.addEventListener('click', () => goBack('welcome'));
+    if (statsBackBtn) statsBackBtn.addEventListener('click', () => goBack('welcome'));
+    if (sourceBackBtn) sourceBackBtn.addEventListener('click', () => goBack('game'));
+    if (calendarBackBtn) calendarBackBtn.addEventListener('click', () => goBack('welcome'));
 }
 
 if (calibrationChart) {

--- a/styles.css
+++ b/styles.css
@@ -557,6 +557,23 @@ button#stats-btn {
     border-radius: 16px;
 }
 
+.guess-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 14px 18px;
+    border-bottom: 2px dashed #eaecef;
+    font-family: 'Nunito', sans-serif;
+    font-weight: 700;
+    font-size: 15px;
+    color: #0f172a;
+}
+
+.guess-header-count {
+    font-weight: 600;
+    color: #4b4b4b;
+}
+
 .guess-row {
     display: flex;
     align-items: center;

--- a/styles.css
+++ b/styles.css
@@ -5,8 +5,10 @@
 }
 
 body {
-    font-family: 'Press Start 2P', monospace;
-    background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32' width='32' height='32' fill='none' stroke='rgb(15 23 42 / 0.04)'%3e%3cpath d='M0 .5H31.5V32'/%3e%3c/svg%3e");
+    font-family: 'Nunito', sans-serif;
+    background-image:
+        linear-gradient(to bottom, transparent 0%, transparent 15%, rgba(255, 255, 255, 0.8) 50%, white 75%),
+        url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32' width='32' height='32' fill='none' stroke='rgb(15 23 42 / 0.04)'%3e%3cpath d='M0 .5H31.5V32'/%3e%3c/svg%3e");
     color: #333;
     line-height: 1.4;
     padding: 0 16px;
@@ -32,6 +34,53 @@ main {
 
 .view.active {
     display: block;
+}
+
+.info-view {
+    max-width: 520px;
+    margin: 0 auto;
+    border-radius: 22px;
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+}
+
+.view-header {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.view-header h2 {
+    font-size: 0.95rem;
+}
+
+.game-view-header {
+    margin-bottom: 16px;
+}
+
+.back-button {
+    background: #fff;
+    border: 2px solid #e9ecef;
+    border-radius: 12px;
+    padding: 10px 14px;
+    font-family: 'Nunito', sans-serif;
+    font-size: 0.6rem;
+    color: #0f172a;
+    cursor: pointer;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    transition: background-color 0.2s ease, border-color 0.2s ease;
+}
+
+.back-button:hover {
+    background-color: rgba(15, 23, 42, 0.08);
+    border-color: #d4d8dd;
+}
+
+.back-button:focus-visible {
+    outline: 2px solid #0f172a;
+    outline-offset: 2px;
 }
 
 .game-container {
@@ -76,7 +125,7 @@ main {
 
 .nav-button {
     background: #fff;
-    font-family: 'Press Start 2P', monospace;
+    font-family: 'Nunito', sans-serif;
     font-size: 0.6rem;
     color: #0f172a;
     border: 2px solid #e9ecef;
@@ -99,15 +148,16 @@ main {
 }
 
 .game-title {
-    font-size: 0.9375rem;
-    width: 150px;
-    font-weight: 400;
+    font-size: 1.1rem;
+    width: 100px;
+    font-weight: 650;
+    line-height: 1.2;
 }
 
 .icon-button {
     background: #fff;
     font-size: 1.1rem;
-    font-family: 'Press Start 2P', monospace;
+    font-family: 'Nunito', sans-serif;
     color: #333;
     cursor: pointer;
     padding: 12px;
@@ -216,7 +266,7 @@ button#stats-btn {
     align-items: center;
     justify-content: center;
     gap: 12px;
-    font-family: 'Press Start 2P', monospace;
+    font-family: 'Nunito', sans-serif;
     font-size: 0.8rem;
     cursor: pointer;
 }
@@ -236,7 +286,7 @@ button#stats-btn {
 .source-btn {
     background: white;
     border: 2px solid #e9ecef;
-    font-family: 'Press Start 2P', monospace;
+    font-family: 'Nunito', sans-serif;
     font-size: 0.8rem;
     border-radius: 0 0 16px 16px;
     color: #333;
@@ -356,7 +406,7 @@ button#stats-btn {
 .strategy-link {
     background: white;
     border: 2px solid #e9ecef;
-    font-family: 'Press Start 2P', monospace;
+    font-family: 'Nunito', sans-serif;
     font-size: 0.82rem;
     padding: 18.75px;
     width: 100%;
@@ -388,7 +438,7 @@ button#stats-btn {
 .hint-link {
     background: transparent;
     border: none;
-    font-family: 'Press Start 2P', monospace;
+    font-family: 'Nunito', sans-serif;
     font-size: 0.82rem;
     padding: 18.75px;
     width: 100%;
@@ -463,7 +513,7 @@ button#stats-btn {
     border: none;
     padding: 12px 25px;
     border-radius: 15px;
-    font-family: 'Press Start 2P', monospace;
+    font-family: 'Nunito', sans-serif;
     font-size: 0.8rem;
     cursor: pointer;
     transition: background-color 0.2s;
@@ -480,7 +530,7 @@ button#stats-btn {
     border: none;
     padding: 15px 25px;
     border-radius: 12px;
-    font-family: 'Press Start 2P', monospace;
+    font-family: 'Nunito', sans-serif;
     font-size: 0.7rem;
     cursor: pointer;
     transition: background-color 0.2s;
@@ -521,7 +571,7 @@ button#stats-btn {
     font-size: 0.835rem;
     text-align: center;
     border: none;
-    font-family: 'Press Start 2P', monospace;
+    font-family: 'Nunito', sans-serif;
     line-height: normal;
     max-height: 48px;
 }
@@ -540,7 +590,7 @@ button#stats-btn {
     align-items: center;
     justify-content: center;
     font-size: 1rem;
-    font-family: 'Press Start 2P', monospace;
+    font-family: 'Nunito', sans-serif;
     cursor: pointer;
     transition: transform 0.2s;
 }
@@ -690,7 +740,7 @@ button#stats-btn {
     background: none;
     border: none;
     font-size: 0.8rem;
-    font-family: 'Press Start 2P', monospace;
+    font-family: 'Nunito', sans-serif;
     outline: none;
     width: 100%;
     padding: 19.5px 15px 14.5px 15px;
@@ -710,7 +760,7 @@ button#stats-btn {
     border: 0;
     color: #333;
     font-size: 0.8rem;
-    font-family: 'Press Start 2P', monospace;
+    font-family: 'Nunito', sans-serif;
     outline: none;
     text-align: center;
     display: none;
@@ -738,7 +788,7 @@ button#stats-btn {
     border-radius: 10px;
     padding: 8px 8px;
     color: #333;
-    font-family: 'Press Start 2P', monospace;
+    font-family: 'Nunito', sans-serif;
     font-size: 0.7rem;
     cursor: pointer;
 }
@@ -809,7 +859,7 @@ button#stats-btn {
     border: 0;
     color: #333;
     font-size: 0.8rem;
-    font-family: 'Press Start 2P', monospace;
+    font-family: 'Nunito', sans-serif;
     text-align: center;
     display: none;
     cursor: pointer;
@@ -840,7 +890,7 @@ button#stats-btn {
     display: none;
     flex-direction: column;
     overflow: hidden;
-    font-family: 'Press Start 2P', monospace;
+    font-family: 'Nunito', sans-serif;
     z-index: 1000;
 }
 
@@ -854,7 +904,7 @@ button#stats-btn {
     border: none;
     color: #333;
     font-size: 0.8rem;
-    font-family: 'Press Start 2P', monospace;
+    font-family: 'Nunito', sans-serif;
     cursor: pointer;
     position: relative;
     text-align: left;
@@ -881,7 +931,7 @@ button#stats-btn {
     border: none;
     padding: 8px 12px;
     border-radius: 12px;
-    font-family: 'Press Start 2P', monospace;
+    font-family: 'Nunito', sans-serif;
     font-size: 0.8rem;
     cursor: pointer;
     transition: background-color 0.2s;
@@ -945,14 +995,6 @@ button#stats-btn {
     font-size: 0.8rem;
 }
 
-/* Accordion inside Source modal */
-.accordion {
-    text-align: left;
-    max-height: calc(90vh - 220px);
-    overflow-y: auto;
-    margin: 16px 0;
-}
-
 .accordion-item {
     border: 2px solid #e9ecef;
     border-radius: 12px;
@@ -969,21 +1011,29 @@ button#stats-btn {
     width: 100%;
     text-align: left;
     background: #fff;
-    color: #333;
+    color: #4b4b4b;
     border: none;
     padding: 14px 16px;
-    font-family: 'Press Start 2P', monospace;
-    font-size: 0.85rem;
+    font-family: 'Nunito', sans-serif;
+    font-size: 19px;
+    font-weight: 700;
     display: flex;
     align-items: center;
     justify-content: space-between;
     cursor: pointer;
-    line-height: 1.4;
 }
 
 .accordion-panel {
     padding: 2px 16px 10px;
     display: none;
+}
+
+.accordion-panel p {
+    color: #777;
+    font-size: 17px;
+    line-height: 24px;
+    font-weight: 500;
+    margin-bottom: 6px;
 }
 
 .accordion-item.open .accordion-panel {
@@ -1001,7 +1051,7 @@ button#stats-btn {
     border: none;
     padding: 15px 25px;
     border-radius: 12px;
-    font-family: 'Press Start 2P', monospace;
+    font-family: 'Nunito', sans-serif;
     font-size: 0.7rem;
     cursor: pointer;
     margin-top: 10px;
@@ -1101,43 +1151,36 @@ button#stats-btn {
 
 /* Comments section */
 .comments-section {
-    display: none;
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background: #fff;
-    z-index: 1000;
-    flex-direction: column;
-    border-radius: 18px;
+    padding: 0 0 48px;
 }
 
-.comments-section.open {
-    display: flex;
+.comments-section.view.active {
+    display: block;
 }
 
-.comments-header {
-    display: flex;
-    align-items: center;
-    gap: 12px;
-    padding: 16px 20px;
+.comments-view {
+    gap: 0;
+}
+
+.comments-view .view-header {
+    padding-bottom: 16px;
     border-bottom: 1px solid #e9ecef;
+    margin-bottom: 0;
 }
 
-.comments-header h2 {
+.comments-view .view-header h2 {
     font-size: 0.9375rem;
 }
 
 .comments-list {
     flex: 1;
     overflow-y: auto;
-    padding: 20px;
+    padding: 24px 0;
 }
 
 .comment {
     margin-bottom: 12px;
-    padding-bottom: 12px;
+    padding: 0 0 12px 0;
     border-bottom: 1px solid #e9ecef;
     font-size: 0.8rem;
 }
@@ -1154,7 +1197,7 @@ button#stats-btn {
 }
 
 .comments-input {
-    padding: 20px;
+    padding: 20px 0 0 0;
     border-top: 1px solid #e9ecef;
     display: flex;
     gap: 10px;
@@ -1168,7 +1211,7 @@ button#stats-btn {
     background: none;
     border: 2px solid #eaecf0;
     border-radius: 15px;
-    font-family: 'Press Start 2P', monospace;
+    font-family: 'Nunito', sans-serif;
     font-size: 0.8rem;
     padding: 18.5px 15px;
     outline: none;
@@ -1177,198 +1220,209 @@ button#stats-btn {
 
 .welcome-content {
     max-width: 520px;
-    margin: 40px auto;
-    background: rgba(255, 255, 255, 0.95);
-    border: 2px solid #e9ecef;
-    border-radius: 22px;
-    padding: 32px 28px;
+    margin: 0 auto;
     text-align: center;
     display: flex;
     flex-direction: column;
-    gap: 26px;
-    box-shadow: 0 18px 35px rgba(15, 23, 42, 0.08);
+    gap: 20px;
 }
 
-.welcome-title {
-    font-size: 1rem;
-}
-
-.welcome-subtitle {
-    font-size: 0.75rem;
-    line-height: 1.6;
-    color: #4b5563;
-}
-
-.daily-challenge-card {
+.welcome-info-card {
+    background: #fff;
     border: 2px solid #e9ecef;
     border-radius: 18px;
     padding: 20px;
     display: flex;
     flex-direction: column;
-    gap: 18px;
+    gap: 8px;
+    text-align: left;
+}
+
+.welcome-info-body {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    margin-bottom: 8px;
+}
+
+.welcome-info-body p {
+    margin: 0;
+}
+
+.welcome-info-note {
+    font-size: 17px;
+    color: #777;
+    line-height: 24px;
+    font-weight: 500;
+}
+
+.daily-challenge-card {
+    --card-accent: #e9ecef;
+    --primary-action-bg: var(--card-accent);
+    --primary-action-shadow: var(--card-accent);
+    --primary-action-text: #0f172a;
+    border: 4px solid var(--card-accent);
+    border-radius: 18px;
+    padding: 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
     background: #fff;
     text-align: left;
+    position: relative;
+}
+
+.daily-challenge-card--ready {
+    --card-accent: #1cb0f6;
+    --primary-action-bg: #1cb0f6;
+    --primary-action-shadow: #1999d6;
+    --primary-action-text: #fff;
+}
+
+.daily-challenge-card--won {
+    --card-accent: #58cc02;
+    --primary-action-bg: var(--card-accent);
+    --primary-action-shadow: #57a700;
+    --primary-action-text: #fff;
+}
+
+.daily-challenge-card--lost {
+    --card-accent: #ff4b4c;
+    --primary-action-bg: var(--card-accent);
+    --primary-action-shadow: #cd3d3d;
+    --primary-action-text: #fff;
+}
+
+.daily-challenge-date-badge {
+    position: absolute;
+    top: -4px;
+    right: -4px;
+    background: var(--card-accent);
+    color: #fff;
+    font-size: 15px;
+    font-weight: 700;
+    text-transform: uppercase;
+    padding: 5px 14px;
+    border-radius: 0 18px 0 18px;
+}
+
+.daily-challenge-date-badge:empty {
+    display: none;
 }
 
 .daily-challenge-header {
     display: flex;
-    justify-content: space-between;
-    align-items: baseline;
+    align-items: center;
 }
 
 .daily-challenge-header h3 {
-    font-size: 0.85rem;
+    font-size: 15px;
     text-transform: uppercase;
-    letter-spacing: 1px;
-}
-
-.daily-challenge-date {
-    font-size: 0.65rem;
-    color: #64748b;
-    text-transform: uppercase;
+    color: #afafaf;
 }
 
 .daily-challenge-body {
     display: flex;
-    gap: 18px;
-    align-items: center;
+    flex-direction: column;
+    gap: 12px;
+    align-items: flex-start;
 }
 
-.daily-challenge-image {
-    width: 76px;
-    height: 76px;
-    border-radius: 14px;
-    border: 2px solid #e9ecef;
-    background: #f8fafc;
+.daily-challenge-text {
     display: flex;
-    align-items: center;
-    justify-content: center;
-    overflow: hidden;
-}
-
-.daily-challenge-image img {
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
+    flex-direction: column;
+    gap: 10px;
+    margin-bottom: 8px;
 }
 
 .daily-challenge-question {
-    font-size: 0.82rem;
-    line-height: 1.6;
-    color: #0f172a;
+    font-size: 21px;
+    line-height: 28px;
+    color: #4b4b4b;
+    font-weight: 700;
 }
 
 .daily-challenge-status {
-    font-size: 0.65rem;
-    color: #475569;
-    margin-top: 6px;
+    font-size: 0.75rem;
+    color: #afafaf;
     text-transform: uppercase;
     letter-spacing: 1px;
+    font-weight: 750;
 }
 
-.daily-challenge-status.status-won {
-    color: #15803d;
+.daily-challenge-actions {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
 }
 
+.daily-challenge-status.status-won,
 .daily-challenge-status.status-lost {
-    color: #b91c1c;
+    color: var(--card-accent);
 }
 
 .primary-action,
 .secondary-action {
-    font-family: 'Press Start 2P', monospace;
-    border-radius: 14px;
+    font-family: 'Nunito', sans-serif;
+    border-radius: 16px;
     cursor: pointer;
     transition: transform 0.15s ease, box-shadow 0.15s ease;
+    text-transform: uppercase;
+    letter-spacing: 0.05rem;
+    font-size: 15px;
+    font-weight: 700;
 }
 
 .primary-action {
-    background: #0f172a;
-    color: #fff;
-    padding: 16px 18px;
+    background: var(--primary-action-bg, #1cb0f6);
+    color: var(--primary-action-text, #fff);
+    padding: 11.25px 18px;
     border: none;
-    font-size: 0.72rem;
-    box-shadow: 0 10px 18px rgba(15, 23, 42, 0.18);
+    box-shadow: 0 4px 0 var(--primary-action-shadow, #1999d6);
 }
 
 .primary-action:hover {
     transform: translateY(-1px);
-    box-shadow: 0 14px 24px rgba(15, 23, 42, 0.2);
+    box-shadow: 0 6px 0 var(--primary-action-shadow, #1999d6);
 }
 
 .primary-action:active {
     transform: translateY(0);
-    box-shadow: 0 6px 12px rgba(15, 23, 42, 0.15);
+    box-shadow: 0 2px 0 var(--primary-action-shadow, #1999d6);
+}
+
+.primary-action:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+    box-shadow: none;
+    transform: none;
 }
 
 .secondary-action {
-    background: transparent;
-    border: 2px solid #0f172a;
-    color: #0f172a;
-    padding: 14px 16px;
-    font-size: 0.62rem;
+    background: #fff;
+    border: 2px solid #eaecef;
+    color: #838181;
+    padding: 11.25px 18px;
+    box-shadow: 0 2px 0 #eaecef;
 }
 
 .secondary-action:hover {
-    background: rgba(15, 23, 42, 0.08);
+    background: rgba(15, 23, 42, 0.03);
 }
 
 .calendar-wrapper {
-    max-width: 900px;
-    margin: 40px auto;
-    background: rgba(255, 255, 255, 0.97);
-    border: 2px solid #e9ecef;
-    border-radius: 22px;
-    padding: 28px 32px 36px;
-    box-shadow: 0 18px 35px rgba(15, 23, 42, 0.08);
+    max-width: 520px;
+    margin: 0 auto;
+}
+
+.calendar-wrapper .view-header {
+    justify-content: flex-start;
+    margin-bottom: 16px;
 }
 
 .calendar-title {
     font-size: 0.95rem;
-    text-align: center;
-    margin-bottom: 10px;
-}
-
-.calendar-subtitle {
-    font-size: 0.72rem;
-    text-align: center;
-    color: #4b5563;
-    margin-bottom: 24px;
-}
-
-.calendar-legend {
-    display: flex;
-    justify-content: center;
-    gap: 18px;
-    flex-wrap: wrap;
-    font-size: 0.58rem;
-    color: #475569;
-    margin-bottom: 24px;
-}
-
-.legend-box {
-    display: inline-block;
-    width: 12px;
-    height: 12px;
-    border-radius: 4px;
-    margin-right: 6px;
-    border: 2px solid #e9ecef;
-    background: #f8fafc;
-}
-
-.legend-box.won {
-    background: #dcfce7;
-    border-color: #16a34a;
-}
-
-.legend-box.lost {
-    background: #fee2e2;
-    border-color: #dc2626;
-}
-
-.legend-box.pending {
-    background: #e2e8f0;
-    border-color: #cbd5f5;
+    margin: 0;
 }
 
 .calendar-months {
@@ -1410,12 +1464,14 @@ button#stats-btn {
 button.calendar-cell {
     border: 2px solid #e9ecef;
     border-radius: 12px;
+    border-bottom-width: 4px;
     min-height: 48px;
     display: flex;
     align-items: center;
     justify-content: center;
-    font-family: 'Press Start 2P', monospace;
-    font-size: 0.68rem;
+    font-family: 'Nunito', sans-serif;
+    font-size: 15px;
+    font-weight: 700;
     background: #fff;
     color: #0f172a;
     cursor: default;
@@ -1471,10 +1527,6 @@ button.calendar-cell:disabled {
     border-color: #0f172a;
 }
 
-.calendar-cell.active {
-    box-shadow: 0 0 0 2px rgba(15, 23, 42, 0.35) inset;
-}
-
 .calendar-month-footer {
     margin-top: 16px;
     font-size: 0.6rem;
@@ -1490,46 +1542,9 @@ button.calendar-cell:disabled {
 }
 
 @media (max-width: 768px) {
-    .welcome-content {
-        margin: 32px auto;
-        padding: 28px 22px;
-    }
-
-    .welcome-title {
-        font-size: 0.9rem;
-    }
-
-    .welcome-subtitle {
-        font-size: 0.68rem;
-    }
-
     .daily-challenge-body {
-        flex-direction: column;
         align-items: flex-start;
-    }
-
-    .daily-challenge-image {
-        width: 68px;
-        height: 68px;
-    }
-
-    .daily-challenge-question {
-        font-size: 0.78rem;
-    }
-
-    .primary-action {
-        font-size: 0.65rem;
-        padding: 14px 16px;
-    }
-
-    .secondary-action {
-        font-size: 0.58rem;
-        padding: 12px 14px;
-    }
-
-    .calendar-wrapper {
-        padding: 24px 20px 30px;
-        margin: 28px auto 48px;
+        gap: 10px;
     }
 
     .calendar-grid {
@@ -1539,7 +1554,7 @@ button.calendar-cell:disabled {
     .calendar-cell,
     button.calendar-cell {
         min-height: 42px;
-        font-size: 0.6rem;
+        font-size: 0.8rem;
     }
 
     .nav-button {
@@ -1555,13 +1570,8 @@ button.calendar-cell:disabled {
         gap: 10px;
     }
 
-    .calendar-cell,
-    button.calendar-cell {
-        min-height: 38px;
-    }
-
     .daily-challenge-card {
-        padding: 18px;
+        padding: 20px;
     }
 }
 
@@ -1602,11 +1612,22 @@ button.calendar-cell:disabled {
         background: #fff;
     }
     body {
-        background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32' width='32' height='32' fill='none' stroke='rgb(15 23 42 / 0.04)'%3e%3cpath d='M0 .5H31.5V32'/%3e%3c/svg%3e");
         padding: 0px 18px;
     }
     body.no-scroll {
         overflow: hidden;
+    }
+    .view-header h2 {
+        font-size: 0.85rem;
+    }
+    .back-button {
+        font-size: 0.52rem;
+        padding: 9px 12px;
+    }
+    .calendar-wrapper .view-header {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 12px;
     }
     .game-header {
         padding: 18px 0;
@@ -1638,7 +1659,7 @@ button.calendar-cell:disabled {
         padding: 25.75px 12px 16px 0;
         font-size: 0.78rem;
         height: 63px;
-        font-family: 'Press Start 2P', monospace;
+        font-family: 'Nunito', sans-serif;
     }
     .source-btn {
         font-size: 0.78rem;
@@ -1651,11 +1672,7 @@ button.calendar-cell:disabled {
         width: 70px;
     }
     .comments-section {
-        position: fixed;
-        left: 0;
-        bottom: 0;
-        border-radius: 18px 18px 0 0;
-        box-shadow: 0 -2px 10px rgba(0,0,0,0.1);
+        padding-bottom: 32px;
     }
 
     main {

--- a/styles.css
+++ b/styles.css
@@ -586,7 +586,7 @@ button#stats-btn {
 
 .guess-field {
     flex: 1;
-    background-color: #f6f6f6;
+    background-color: #fff;
     color: #333;
     padding: 17.5px 15px;
     border-radius: 13px;
@@ -596,6 +596,10 @@ button#stats-btn {
     font-family: 'Nunito', sans-serif;
     line-height: normal;
     max-height: 48px;
+}
+
+.guess-field.active {
+    background-color: #fcfcfc;
 }
 
 .guess-field.empty {

--- a/styles.css
+++ b/styles.css
@@ -553,13 +553,18 @@ button#stats-btn {
     margin-bottom: 20px;
     position: relative;
     z-index: 6; /* ensure tooltips above .question-box (z-index:5) */
+    border: 2px solid #eaecef;
+    border-radius: 16px;
 }
 
 .guess-row {
     display: flex;
     align-items: center;
-    margin-bottom: 5px;
     gap: 5px;
+}
+
+.guess-row:not(:last-child) {
+    border-bottom: 2px dashed #eaecef;
 }
 
 .guess-field {
@@ -579,6 +584,30 @@ button#stats-btn {
 .guess-field.empty {
     color: #b3b3b3;
     font-size: 0.8rem;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 12px;
+    text-align: left;
+}
+
+.guess-placeholder-text {
+    font-weight: 600;
+}
+
+.guess-placeholder-percentage {
+    border: 2px solid #e5e5e5;
+    padding: 7px;
+    border-radius: 8px;
+    font-weight: 700;
+    font-size: 15px;
+    color: #afafaf;
+    font-family: 'Nunito', sans-serif;
+    background: white;
+}
+
+.guess-placeholder-percentage.hidden {
+    display: none;
 }
 
 .feedback-button {


### PR DESCRIPTION
## Summary
- fetch the per-question guess distribution from Supabase and cache it for reuse
- surface the percentage of winners per guess in the empty guess rows and refresh after completion
- remove the extra margin from the daily challenge status label

## Testing
- node --check script.js

------
https://chatgpt.com/codex/tasks/task_e_68cd1f5126a88329afe1d74f192aebac