### PR TITLE
Add email subscription banner and modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,19 @@
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
 </head>
 <body>
+        <div class="info-banner info-banner--hidden" id="info-banner" role="region" aria-live="polite">
+            <div class="info-banner__content">
+                <span class="info-banner__icon" aria-hidden="true">📬</span>
+                <div class="info-banner__text">
+                    <strong>Get the daily question by email.</strong>
+                    <span>We’ll ping you when a new Fermi question is live.</span>
+                </div>
+            </div>
+            <div class="info-banner__actions">
+                <button id="banner-subscribe-btn" class="info-banner__action">Notify me</button>
+            </div>
+            <button id="banner-close-btn" class="info-banner__close" aria-label="Dismiss notification banner">&times;</button>
+        </div>
         <header class="game-header">
             <div class="header-left">
                 <img src="https://upload.wikimedia.org/wikipedia/commons/6/6f/Photograph_of_Enrico_Fermi_-_NARA_-_595043.gif" alt="Enrico Fermi" class="fermi-logo">
@@ -180,6 +193,26 @@
                 <p id="modal-message"></p>
                 <p id="modal-answer"></p>
                 <button id="new-game-btn" class="new-game-btn">New Game</button>
+            </div>
+        </div>
+
+        <!-- Email subscription modal -->
+        <div class="modal" id="email-modal" role="dialog" aria-modal="true" aria-labelledby="email-modal-title" aria-hidden="true">
+            <div class="modal-content modal-content--narrow">
+                <h2 id="email-modal-title">Daily question reminders</h2>
+                <p>Leave your email and we’ll send the new Fermi question straight to your inbox.</p>
+                <form id="email-form" class="email-form">
+                    <label for="email-input">Email address</label>
+                    <input type="email" id="email-input" name="email" placeholder="you@example.com" autocomplete="email" required>
+
+                    <label for="timezone-select">Time zone</label>
+                    <select id="timezone-select" name="timezone" required></select>
+                    <p class="timezone-note">We’ll schedule the email for around 9 AM in your time zone.</p>
+
+                    <button type="submit" id="email-submit-btn" class="primary-btn">Subscribe</button>
+                    <p id="email-feedback" class="form-feedback" aria-live="polite"></p>
+                </form>
+                <button id="close-email-modal" class="close-btn">Close</button>
             </div>
         </div>
 

--- a/script.js
+++ b/script.js
@@ -1263,6 +1263,16 @@ const commentsList = document.getElementById('comments-list');
 const commentInput = document.getElementById('comment-input');
 const commentSubmitBtn = document.getElementById('comment-submit-btn');
 const commentCountEl = document.getElementById('comment-count');
+const infoBanner = document.getElementById('info-banner');
+const bannerCloseBtn = document.getElementById('banner-close-btn');
+const bannerSubscribeBtn = document.getElementById('banner-subscribe-btn');
+const emailModal = document.getElementById('email-modal');
+const emailForm = document.getElementById('email-form');
+const emailInput = document.getElementById('email-input');
+const emailTimezoneSelect = document.getElementById('timezone-select');
+const emailFeedback = document.getElementById('email-feedback');
+const closeEmailModalBtn = document.getElementById('close-email-modal');
+const emailSubmitBtn = document.getElementById('email-submit-btn');
 
 
 // Confidence tooltip
@@ -1283,6 +1293,243 @@ function initConfidenceTooltip() {
     document.addEventListener('touchstart', hideTooltip, { once: true });
 }
 
+function detectUserTimeZone() {
+    try {
+        const options = Intl.DateTimeFormat().resolvedOptions();
+        if (options && options.timeZone) {
+            return options.timeZone;
+        }
+    } catch (error) {
+        // Ignore and fall back to UTC
+    }
+    return 'UTC';
+}
+
+function formatTimeZoneLabel(zone) {
+    if (!zone) return '';
+    return zone.replace(/_/g, ' ');
+}
+
+function populateTimezoneOptions(selectedZone) {
+    if (!emailTimezoneSelect) return;
+    const storedZone = localStorage.getItem('emailTimezone');
+    const preferredZone = storedZone || selectedZone || detectUserTimeZone();
+    let zones = [];
+    try {
+        if (typeof Intl !== 'undefined' && typeof Intl.supportedValuesOf === 'function') {
+            zones = Intl.supportedValuesOf('timeZone');
+        }
+    } catch (error) {
+        // Ignore feature detection errors
+    }
+
+    if (!Array.isArray(zones) || zones.length === 0) {
+        zones = [
+            'UTC',
+            'America/New_York',
+            'America/Los_Angeles',
+            'Europe/London',
+            'Europe/Berlin',
+            'Asia/Singapore',
+            'Australia/Sydney'
+        ];
+    }
+
+    const zoneSet = new Set(zones);
+    if (preferredZone) {
+        zoneSet.add(preferredZone);
+    }
+
+    emailTimezoneSelect.innerHTML = '';
+    Array.from(zoneSet)
+        .sort()
+        .forEach(zone => {
+            const option = document.createElement('option');
+            option.value = zone;
+            option.textContent = formatTimeZoneLabel(zone);
+            emailTimezoneSelect.appendChild(option);
+        });
+
+    if (preferredZone && zoneSet.has(preferredZone)) {
+        emailTimezoneSelect.value = preferredZone;
+    }
+}
+
+function showInfoBanner() {
+    if (!infoBanner) return;
+    infoBanner.classList.remove('info-banner--hidden');
+}
+
+function hideInfoBanner({ persistDismissal = false } = {}) {
+    if (!infoBanner) return;
+    infoBanner.classList.add('info-banner--hidden');
+    if (persistDismissal) {
+        localStorage.setItem('emailBannerDismissed', 'true');
+    }
+}
+
+function initEmailCapture() {
+    populateTimezoneOptions(detectUserTimeZone());
+
+    const dismissed = localStorage.getItem('emailBannerDismissed') === 'true';
+    if (!dismissed) {
+        showInfoBanner();
+    } else {
+        hideInfoBanner();
+    }
+}
+
+function openEmailModal() {
+    if (!emailModal) return;
+    populateTimezoneOptions(detectUserTimeZone());
+    clearEmailFeedback();
+    emailModal.style.display = 'block';
+    emailModal.setAttribute('aria-hidden', 'false');
+    if (emailInput) {
+        setTimeout(() => emailInput.focus(), 50);
+    }
+}
+
+function closeEmailModal() {
+    if (!emailModal) return;
+    closeModal(emailModal);
+    emailModal.setAttribute('aria-hidden', 'true');
+    if (emailForm) {
+        emailForm.reset();
+    }
+    populateTimezoneOptions(detectUserTimeZone());
+    clearEmailFeedback();
+}
+
+function clearEmailFeedback() {
+    setEmailFeedback('', null);
+}
+
+function setEmailFeedback(message, type = 'info') {
+    if (!emailFeedback) return;
+    emailFeedback.textContent = message || '';
+    emailFeedback.classList.remove('form-feedback--success', 'form-feedback--error', 'form-feedback--info');
+    if (message && type) {
+        emailFeedback.classList.add(`form-feedback--${type}`);
+    }
+}
+
+function isValidEmail(email) {
+    if (!email) return false;
+    const trimmed = email.trim();
+    return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(trimmed);
+}
+
+async function handleEmailSubscription(event) {
+    event.preventDefault();
+    if (!emailForm || !emailInput) return;
+
+    const email = emailInput.value.trim().toLowerCase();
+    if (!isValidEmail(email)) {
+        setEmailFeedback('Please enter a valid email address.', 'error');
+        return;
+    }
+
+    if (!supabase) {
+        initSupabase();
+    }
+
+    if (!supabase) {
+        setEmailFeedback('Subscription is unavailable right now. Please try again later.', 'error');
+        return;
+    }
+
+    const timezone = emailTimezoneSelect && emailTimezoneSelect.value ? emailTimezoneSelect.value : detectUserTimeZone();
+    localStorage.setItem('emailTimezone', timezone);
+
+    setEmailFeedback('Saving your subscription…', 'info');
+
+    let originalButtonText = null;
+    if (emailSubmitBtn) {
+        originalButtonText = emailSubmitBtn.textContent;
+        emailSubmitBtn.disabled = true;
+        emailSubmitBtn.textContent = 'Saving…';
+    }
+
+    try {
+        const payload = {
+            email,
+            timezone,
+            subscribed_at: new Date().toISOString()
+        };
+
+        const { error: upsertError } = await supabase
+            .from('email_subscribers')
+            .upsert(payload, { onConflict: 'email' });
+
+        if (upsertError) {
+            throw upsertError;
+        }
+
+        let functionRegistered = false;
+        try {
+            // Trigger Supabase Edge Function that stores the subscription and schedules Resend deliveries.
+            const { error: functionError } = await supabase.functions.invoke('register-daily-question-email', {
+                body: {
+                    email,
+                    timezone
+                }
+            });
+            if (!functionError) {
+                functionRegistered = true;
+            } else {
+                console.warn('Daily email registration function returned an error:', functionError);
+            }
+        } catch (invokeError) {
+            console.warn('Failed to invoke daily email registration function:', invokeError);
+        }
+
+        try {
+            // Fire-and-forget welcome message through a Supabase Edge Function that calls Resend.
+            await supabase.functions.invoke('send-welcome-email', {
+                body: {
+                    email,
+                    timezone
+                }
+            });
+        } catch (welcomeError) {
+            console.warn('Welcome email invocation failed:', welcomeError);
+        }
+
+        setEmailFeedback(
+            functionRegistered
+                ? 'You’re in! We’ll email you each morning when the new question goes live.'
+                : 'Subscription saved! Emails will begin shortly — if you do not receive one, please try again later.',
+            'success'
+        );
+
+        emailInput.value = '';
+        if (emailSubmitBtn && originalButtonText) {
+            emailSubmitBtn.textContent = originalButtonText;
+        }
+        if (emailSubmitBtn) {
+            emailSubmitBtn.disabled = false;
+        }
+
+        hideInfoBanner({ persistDismissal: true });
+        localStorage.setItem('emailSubscribed', 'true');
+
+        setTimeout(() => {
+            closeEmailModal();
+        }, 1600);
+    } catch (error) {
+        console.error('Email subscription failed:', error);
+        setEmailFeedback('We could not save your email. Please try again in a moment.', 'error');
+    } finally {
+        if (emailSubmitBtn) {
+            emailSubmitBtn.disabled = false;
+            if (originalButtonText) {
+                emailSubmitBtn.textContent = originalButtonText;
+            }
+        }
+    }
+}
+
 // Initialize game
 function initGame() {
     // Initialize Supabase first
@@ -1292,6 +1539,7 @@ function initGame() {
     loadCompletedQuestions();
     loadCalibrationSetting();
     initConfidenceTooltip();
+    initEmailCapture();
 
     // If URL has a specific question date, navigate to it first
     let navigatedFromURL = false;
@@ -3235,6 +3483,28 @@ function setupEventListeners() {
         });
     }
 
+    if (bannerCloseBtn) {
+        bannerCloseBtn.addEventListener('click', () => hideInfoBanner({ persistDismissal: true }));
+    }
+
+    if (bannerSubscribeBtn) {
+        bannerSubscribeBtn.addEventListener('click', openEmailModal);
+    }
+
+    if (closeEmailModalBtn) {
+        closeEmailModalBtn.addEventListener('click', closeEmailModal);
+    }
+
+    if (emailForm) {
+        emailForm.addEventListener('submit', handleEmailSubscription);
+    }
+
+    if (emailTimezoneSelect) {
+        emailTimezoneSelect.addEventListener('change', () => {
+            localStorage.setItem('emailTimezone', emailTimezoneSelect.value);
+        });
+    }
+
     // Mobile-only custom confidence dropdown
     if (confidenceButton && confidenceMenu && guessInput) {
         const menuButtons = confidenceMenu.querySelectorAll('button[data-value]');
@@ -3395,12 +3665,21 @@ function setupEventListeners() {
     shareStatsBtn.addEventListener('click', shareStats);
         
     // Close modals when clicking outside (desktop + mobile)
-    [helpModal, statsModal, questionsModal, sourceModal].forEach(modal => {
-        ['click', 'touchend'].forEach(event => {
-            modal.addEventListener(event, e => e.target === modal && closeModal(modal));
+    [helpModal, statsModal, questionsModal, sourceModal, emailModal]
+        .filter(Boolean)
+        .forEach(modal => {
+            ['click', 'touchend'].forEach(event => {
+                modal.addEventListener(event, e => {
+                    if (e.target !== modal) return;
+                    if (modal === emailModal) {
+                        closeEmailModal();
+                    } else {
+                        closeModal(modal);
+                    }
+                });
+            });
         });
-    });
-    
+
     // Prevent modal content clicks from closing modals
     document.querySelectorAll('.modal-content').forEach(content => {
         ['click', 'touchend'].forEach(event => {

--- a/styles.css
+++ b/styles.css
@@ -20,6 +20,91 @@ button {
     touch-action: manipulation;
 }
 
+.info-banner {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    background: #ffffff;
+    border: 2px solid #e9ecef;
+    border-radius: 18px;
+    padding: 14px 18px;
+    margin: 18px auto 8px;
+    max-width: 520px;
+    position: relative;
+    box-shadow: 0 12px 24px rgba(15, 23, 42, 0.08);
+}
+
+.info-banner--hidden {
+    display: none;
+}
+
+.info-banner__content {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    flex: 1;
+}
+
+.info-banner__icon {
+    font-size: 1.4rem;
+}
+
+.info-banner__text {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    font-size: 0.7rem;
+    line-height: 1.45;
+}
+
+.info-banner__text strong {
+    font-size: 0.72rem;
+    color: #1f2937;
+}
+
+.info-banner__actions {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.info-banner__action {
+    background: #2e86c1;
+    color: #fff;
+    border: none;
+    border-radius: 14px;
+    padding: 10px 16px;
+    font-family: 'Press Start 2P', monospace;
+    font-size: 0.7rem;
+    cursor: pointer;
+    box-shadow: 0 6px 15px rgba(46, 134, 193, 0.35);
+    transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.info-banner__action:hover,
+.info-banner__action:focus {
+    background: #236699;
+    transform: translateY(-1px);
+}
+
+.info-banner__close {
+    position: absolute;
+    top: 10px;
+    right: 12px;
+    border: none;
+    background: transparent;
+    color: #6b7280;
+    font-size: 1.1rem;
+    cursor: pointer;
+    padding: 6px;
+    line-height: 1;
+}
+
+.info-banner__close:hover,
+.info-banner__close:focus {
+    color: #111827;
+}
+
 .game-container {
     max-width: 500px;
     margin: 0 auto;
@@ -84,6 +169,29 @@ button {
 
 button#stats-btn {
     padding-right: 10px;
+}
+
+@media (max-width: 560px) {
+    .info-banner {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 12px;
+        padding: 16px;
+    }
+
+    .info-banner__actions {
+        width: 100%;
+    }
+
+    .info-banner__action {
+        width: 100%;
+        text-align: center;
+    }
+
+    .info-banner__close {
+        top: 12px;
+        right: 12px;
+    }
 }
 
 /* Question Container */
@@ -908,6 +1016,96 @@ button#stats-btn {
     line-height: 1.4;
     color: #555;
     font-size: 0.8rem;
+}
+
+.modal-content--narrow {
+    max-width: 420px;
+}
+
+.email-form {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    text-align: left;
+}
+
+.email-form label {
+    font-size: 0.68rem;
+    color: #374151;
+}
+
+.email-form input,
+.email-form select {
+    width: 100%;
+    padding: 12px;
+    border: 2px solid #e9ecef;
+    border-radius: 12px;
+    background: #fff;
+    font-family: 'Press Start 2P', monospace;
+    font-size: 0.75rem;
+    color: #111827;
+}
+
+.email-form select {
+    appearance: none;
+    background-image: linear-gradient(45deg, transparent 50%, #111827 50%), linear-gradient(135deg, #111827 50%, transparent 50%);
+    background-position: calc(100% - 18px) calc(50% - 4px), calc(100% - 12px) calc(50% - 4px);
+    background-size: 6px 6px, 6px 6px;
+    background-repeat: no-repeat;
+}
+
+.email-form input:focus,
+.email-form select:focus {
+    outline: none;
+    border-color: #2e86c1;
+    box-shadow: 0 0 0 3px rgba(46, 134, 193, 0.25);
+}
+
+.timezone-note {
+    font-size: 0.66rem;
+    color: #6b7280;
+    margin-top: -6px;
+}
+
+.primary-btn {
+    background: #2e86c1;
+    color: #fff;
+    border: none;
+    border-radius: 14px;
+    padding: 12px 16px;
+    font-family: 'Press Start 2P', monospace;
+    font-size: 0.75rem;
+    cursor: pointer;
+    transition: background 0.2s ease;
+}
+
+.primary-btn:hover,
+.primary-btn:focus {
+    background: #236699;
+}
+
+.primary-btn:disabled {
+    background: #9bbfe2;
+    cursor: not-allowed;
+}
+
+.form-feedback {
+    min-height: 18px;
+    font-size: 0.66rem;
+    color: #4b5563;
+    margin-top: -2px;
+}
+
+.form-feedback--success {
+    color: #0f5132;
+}
+
+.form-feedback--error {
+    color: #842029;
+}
+
+.form-feedback--info {
+    color: #1f2937;
 }
 
 /* Accordion inside Source modal */


### PR DESCRIPTION
## Summary
- add a closable info banner above the header that invites players to subscribe
- implement an email capture modal that stores subscriptions in Supabase and triggers Resend edge functions for welcome/daily mailings
- style the banner and modal with responsive layouts and persist dismissal/timezone preferences

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e407d7e00c8329910a4253b72c1ddf